### PR TITLE
Scripts to automate install/uninstall on macos

### DIFF
--- a/scripts/Auto-install-macos.sh
+++ b/scripts/Auto-install-macos.sh
@@ -1,0 +1,149 @@
+#!/bin/zsh
+# A script to autoamtically install jellyfin-rpc on mac
+clear
+
+# Get the user's server information
+vared -p "Jellyfin Server URL (include http/https): " -c jellyfinurl
+vared -p "Jellyfin API Key (you can find this at ${jellyfinurl}/web/#!/apikeys.html): " -c jellyfinkey
+vared -p "Jellyfin Username: " -c jellyfinuser
+
+# Prompt the user for what libraries should be included/blocked
+responses=()
+
+vared -p "Include Movies in Discord Rich Presence? (y/n) " -c moviesEnabled
+if [[ $moviesEnabled == [Nn]* ]]; then
+  responses+=( "movie" )
+fi
+
+vared -p "Include TV in Discord Rich Presence? (y/n) " -c tvEnabled
+if [[ $tvEnabled == [Nn]* ]]; then
+  responses+=( "episode" )
+fi
+
+vared -p "Include Music in Discord Rich Presence? (y/n) " -c musicEnabled
+if [[ $musicEnabled == [Nn]* ]]; then
+  responses+=( "music" )
+fi
+
+vared -p "Include Live TV in Discord Rich Presence? (y/n) " -c livetvEnabled
+if [[ $livetvEnabled == [Nn]* ]]; then
+  responses+=( "livetv" )
+fi
+
+# Build the blocklist string
+if [[ ${#responses} -eq 0 ]]; then
+  blocklistString='["movie", "episode", "music", "livetv"]'
+else
+  blocklistString='['
+  for i in ${responses[@]}; do
+    blocklistString+="\"$i\", "
+  done
+  blocklistString=${blocklistString%?}
+  blocklistString=${blocklistString%?}
+  blocklistString+=']'
+fi
+
+#get discord application ID, or use default if left blank
+vared -p "Discord Application ID (leave blank if you're unsure): " -c discordAppId
+if [ -z $discordAppId ]; then
+  discordAppId="1053747938519679018"
+fi
+
+# Get Imgur client ID & enable/disable image uploading
+configImgurEnabled="false"
+vared -p "Upload album artwork to Imgur to be displayed in discord? (y/n) " -c artworkEnabled
+if [[ $artworkEnabled == [Yy]* ]]; then
+  configImgurEnabled="true"
+  echo "To get an Imgur client ID, go to https://api.imgur.com/oauth2/addclient"
+  echo "Name can be anything, authorization type must be 'OAuth 2 authorization without a callback URL'"
+  echo "Press submit to get your client ID"
+  echo "NOTE: Port formwarding must be enabled on your server to send images"
+  vared -p "Imgur client ID (): " -c imgurId
+fi
+
+#put together the config file
+
+configFileContents=""
+configFileContents+="$(cat <<EOF
+{
+    "Jellyfin": {
+        "URL": "${jellyfinurl}",
+        "API_KEY": "${jellyfinkey}",
+        "USERNAME": "${jellyfinuser}"
+EOF
+)"
+if [[ ${#responses} -ne 0 ]]; then # only add this line if there are items in the blocklist
+  configFileContents+="$(cat <<EOF
+,
+        "BLOCKLIST": ${blocklistString}
+EOF
+)"
+fi
+configFileContents+="$(cat <<EOF
+
+    },
+    "Discord": {
+        "APPLICATION_ID": "${discordAppId}"
+    },
+    "Imgur": {
+        "CLIENT_ID": "${imgurId}"
+    },
+    "Images": {
+        "ENABLE_IMAGES": ${configImgurEnabled},
+        "IMGUR_IMAGES": ${configImgurEnabled}
+    }
+}
+EOF
+)"
+
+# Preview config file and have user confirm before saving it
+echo "Config file preview:"
+echo $configFileContents
+vared -p "Save it and proceed? (y/n) " -c proceed
+if [[ $proceed == [Nn]* ]]; then
+  exit
+fi
+
+#Save config to file
+if [ ! -d ~/.config/jellyfin-rpc ]; then
+  mkdir ~/.config/jellyfin-rpc
+fi
+echo $configFileContents > ~/.config/jellyfin-rpc/main.json
+
+# Prompt user to install Jellyfin RPC
+vared -p "Download latest release? (y/n) " -c downloadlatest
+if [[ $downloadlatest == [Yy]* ]]; then
+  # download file to binary directory and give execution permissions
+  curl -o /usr/local/bin/jellyfin-rpc -L https://github.com/Radiicall/jellyfin-rpc/releases/latest/download/jellyfin-rpc-x86_64-darwin
+  chmod +x /usr/local/bin/jellyfin-rpc
+
+  # Prompt user to enabled Jellyfin RPC running at login
+  vared -p "Set Jellyfin-RPC to run at login? (y/n) " -c runAtLogin
+  if [[ $runAtLogin == [Yy]* ]]; then
+    # Create launch agent file, give it proper permissions, then load it.
+    cat >> ~/Library/LaunchAgents/jellyfinrpc.local.plist<< EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>Jellyfin-RPC</string>
+    <key>Program</key>
+    <string>/usr/local/bin/jellyfin-rpc</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardErrorPath</key>
+    <string>/tmp/jellyfinrpc.local.stderr.txt</string>
+    <key>StandardOutPath</key>
+    <string>/tmp/jellyfinrpc.local.stdout.txt</string>
+</dict>
+</plist>
+EOF
+    chmod 644 ~/Library/LaunchAgents/jellyfinrpc.local.plist
+    launchctl unload ~/Library/LaunchAgents/jellyfinrpc.local.plist #It seems that the OS tries to load the launch agent on creation, so it needs unloaded first.
+    launchctl load ~/Library/LaunchAgents/jellyfinrpc.local.plist
+  fi
+  echo "If needed, you can run Jellyfin RPC at any time by running 'jellyfin-rpc' in a terminal"
+fi
+
+exit

--- a/scripts/uninstall-macos.sh
+++ b/scripts/uninstall-macos.sh
@@ -1,6 +1,11 @@
 #!/bin/zsh
 # A script to autoamtically uninstall jellyfin-rpc on mac
-killall jellyfin-rpc #stop any running processes
+if pgrep -xq -- "jellyfin-rpc"; then
+    killall jellyfin-rpc # Kill jellyfin-rpc if it is running
+fi
+if launchctl list | grep Jellyfin-RPC; then
+    launchctl remove Jellyfin-RPC # Unload Jellyfin-RPC launchagent if it is loaded
+fi
 rm ~/Library/LaunchAgents/jellyfinrpc.local.plist #remove launch agent
 rm -rf ~/.config/jellyfin-rpc #remove config file
 rm /usr/local/bin/jellyfin-rpc #remove binary

--- a/scripts/uninstall-macos.sh
+++ b/scripts/uninstall-macos.sh
@@ -1,0 +1,6 @@
+#!/bin/zsh
+# A script to autoamtically uninstall jellyfin-rpc on mac
+killall jellyfin-rpc #stop any running processes
+rm ~/Library/LaunchAgents/jellyfinrpc.local.plist #remove launch agent
+rm -rf ~/.config/jellyfin-rpc #remove config file
+rm /usr/local/bin/jellyfin-rpc #remove binary

--- a/scripts/uninstall-macos.sh
+++ b/scripts/uninstall-macos.sh
@@ -9,3 +9,4 @@ fi
 rm ~/Library/LaunchAgents/jellyfinrpc.local.plist #remove launch agent
 rm -rf ~/.config/jellyfin-rpc #remove config file
 rm /usr/local/bin/jellyfin-rpc #remove binary
+echo "Uninstall complete!"


### PR DESCRIPTION
Saw the invitation for someone to make a linux script to automate installation, hoped the offer extended to macOS as well.

I didn't do much in terms of UI, but it:

- creates the config file
  - Asks user for all needed info
  - Provides information on where to find needed values, akin to the readme.md instructions
  - Confirms that the config file looks right before making any changes to the user's system
- downloads the program to the macOS binary folder
  - curls the latest release & saves it to /usr/local/bin
  - makes it executable
- Creates a Launch Agent so that the program can start itself at login and run in the background
  - Saves the needed .plist and applies proper permissions
  - Immediately loads jellyfin-rpc so that user doesn't have to log out & back in before it starts running

If I'm not mistaken, this could be adapted fairly easily into a linux installer, it would just need to be rewritten for bash rather than zsh, and with respect to any differing file paths.

Tested on a Macbook Air M1 running Ventura 13.3.1