### PR TITLE
Add support for books

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jellyfin-rpc"
-version = "0.14.7"
+version = "0.15.0"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jellyfin-rpc"
-version = "0.14.7"
+version = "0.15.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -21,26 +21,30 @@ For setup instructions refer to the [Wiki](https://github.com/Radiicall/jellyfin
 
 #### Movie
 
-![Jellyfin-RPC Displaying a Movie](https://github.com/Radiicall/jellyfin-rpc/assets/66682497/95530d9c-72c9-47c2-bd67-645e444bbe21)
+![Jellyfin-RPC Displaying a Movie in Discord](https://github.com/Radiicall/jellyfin-rpc/assets/66682497/95530d9c-72c9-47c2-bd67-645e444bbe21)
 
 #### Episode
 
-![Jellyfin-RPC Displaying a TV Show Episode](https://github.com/Radiicall/jellyfin-rpc/assets/66682497/0a552046-350b-415d-913a-8956723e5684)
+![Jellyfin-RPC Displaying a TV Show Episode in Discord](https://github.com/Radiicall/jellyfin-rpc/assets/66682497/0a552046-350b-415d-913a-8956723e5684)
 
 #### Music
 
-![Jellyfin-RPC Displaying a Song](https://github.com/Radiicall/jellyfin-rpc/assets/66682497/103b84af-a9c9-49e4-9a15-c5c47051a994)
+![Jellyfin-RPC Displaying a Song in Discord](https://github.com/Radiicall/jellyfin-rpc/assets/66682497/103b84af-a9c9-49e4-9a15-c5c47051a994)
 
 #### Live TV
 
-![Jellyfin-RPC Displaying a TV Channel](https://github.com/Radiicall/jellyfin-rpc/assets/66682497/1d9cf0af-96f2-438b-b147-904ab65bcc48)
+![Jellyfin-RPC Displaying a TV Channel in Discord](https://github.com/Radiicall/jellyfin-rpc/assets/66682497/1d9cf0af-96f2-438b-b147-904ab65bcc48)
+
+#### Book
+
+![Jellyfin-RPC Displaying a Book in Discord](https://github.com/Radiicall/jellyfin-rpc/assets/66682497/0a37013f-5fba-43fc-afa4-ba67baf2509d)
 
 #### Audiobook
 
-![Jellyfin-RPC Displaying an Audiobook](https://github.com/Radiicall/jellyfin-rpc/assets/66682497/3a7845ae-0219-4932-a1a2-efb44f40a171)
+![Jellyfin-RPC Displaying an Audiobook in Discord](https://github.com/Radiicall/jellyfin-rpc/assets/66682497/3a7845ae-0219-4932-a1a2-efb44f40a171)
 
 #### Terminal
 
-![Image of terminal output](https://github.com/Radiicall/jellyfin-rpc/assets/66682497/4da2c59e-f6c7-49d8-89f6-b2704d9b66c3)
+![Image of terminal/cmd output](https://github.com/Radiicall/jellyfin-rpc/assets/66682497/4da2c59e-f6c7-49d8-89f6-b2704d9b66c3)
 
 </details>

--- a/src/main.rs
+++ b/src/main.rs
@@ -365,25 +365,20 @@ fn setactivity<'a>(
         .large_text(version)
         .large_image(image_url);
 
-    if media_type != &MediaType::LiveTv {
-        match endtime {
-            Some(time) => {
-                new_activity = new_activity
-                    .clone()
-                    .timestamps(activity::Timestamps::new().end(time));
-            }
-            None => {
-                assets = assets
-                    .clone()
-                    .small_image("https://i.imgur.com/wlHSvYy.png")
-                    .small_text("Paused");
-            }
+    match endtime {
+        Some(_) if media_type == &MediaType::LiveTv => (),
+        Some(time) => {
+            new_activity = new_activity
+                .clone()
+                .timestamps(activity::Timestamps::new().end(time));
         }
-    } else if endtime.is_none() {
-        assets = assets
-            .clone()
-            .small_image("https://i.imgur.com/wlHSvYy.png")
-            .small_text("Paused");
+        None if media_type == &MediaType::Book => (),
+        None => {
+            assets = assets
+                .clone()
+                .small_image("https://i.imgur.com/wlHSvYy.png")
+                .small_text("Paused");
+        }
     }
 
     if !state_message.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -252,11 +252,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     &content.media_type,
                 ))
                 .unwrap_or_else(|err| {
-                    eprintln!(
-                        "{}\nError: {}",
-                        "Failed to set activity".red().bold(),
-                        err
-                    );
+                    eprintln!("{}\nError: {}", "Failed to set activity".red().bold(), err);
                     retry_with_index(
                         retry::delay::Exponential::from_millis(1000),
                         |current_try| {

--- a/src/services/jellyfin.rs
+++ b/src/services/jellyfin.rs
@@ -241,7 +241,7 @@ impl Content {
             content.item_id(now_playing_item["Id"].as_str()?.to_string());
         } else if now_playing_item["Type"].as_str()? == "Book" {
             // Time to convert jellyfin nonsense into pages!!!
-            let ticks_to_pages = 	10000;
+            let ticks_to_pages = 10000;
 
             let mut position_ticks = play_state["PositionTicks"].as_i64().unwrap_or(0);
             position_ticks /= ticks_to_pages;

--- a/src/services/jellyfin.rs
+++ b/src/services/jellyfin.rs
@@ -118,8 +118,9 @@ impl Content {
             let mut content = ContentBuilder::new();
 
             let now_playing_item = &session["NowPlayingItem"];
+            let play_state = &session["PlayState"];
 
-            Content::watching(&mut content, now_playing_item, config).await;
+            Content::watching(&mut content, now_playing_item, play_state, config).await;
 
             // Check that details and state_message arent over the max length allowed by discord, if they are then they have to be trimmed down because discord wont display the activity otherwise
             if content.details.len() > 128 {
@@ -139,8 +140,12 @@ impl Content {
             {
                 image_url = Content::image(&config.jellyfin.url, content.item_id.clone()).await;
             }
+
             content.external_services(ExternalServices::get(now_playing_item).await);
-            content.endtime(Content::time_left(now_playing_item, &session).await);
+
+            if content.media_type != MediaType::Book {
+                content.endtime(Content::time_left(now_playing_item, play_state).await);
+            }
             content.image_url(image_url);
 
             return Ok(content.build());
@@ -151,6 +156,7 @@ impl Content {
     async fn watching(
         content: &mut ContentBuilder,
         now_playing_item: &Value,
+        play_state: &Value,
         config: &Config,
     ) -> Option<()> {
         /*
@@ -233,11 +239,18 @@ impl Content {
             content.details(name.into());
             content.state_message("Live TV".into());
             content.item_id(now_playing_item["Id"].as_str()?.to_string());
-        } else if now_playing_item["Type"].as_str()? == "AudioBook" {
-            content.media_type(MediaType::AudioBook);
-            content.item_id(now_playing_item["ParentId"].as_str()?.to_string());
-            content.details(now_playing_item["Album"].as_str().unwrap_or(name).into());
+        } else if now_playing_item["Type"].as_str()? == "Book" {
+            // Time to convert jellyfin nonsense into pages!!!
+            let ticks_to_pages = 	10000;
 
+            let mut position_ticks = play_state["PositionTicks"].as_i64().unwrap_or(0);
+            position_ticks /= ticks_to_pages;
+
+            content.state_message(format!("Reading page {}", position_ticks));
+            content.media_type(MediaType::Book);
+            content.details(name.into());
+            content.item_id(now_playing_item["Id"].as_str()?.to_string());
+        } else if now_playing_item["Type"].as_str()? == "AudioBook" {
             let raw_artists = now_playing_item["Artists"]
                 .as_array()?
                 .iter()
@@ -263,16 +276,19 @@ impl Content {
                 genres = String::from(" - ") + &genres
             }
 
+            content.media_type(MediaType::AudioBook);
+            content.item_id(now_playing_item["ParentId"].as_str()?.to_string());
+            content.details(now_playing_item["Album"].as_str().unwrap_or(name).into());
             content.state_message(format!("By {}{}", artists, genres))
         }
         Some(())
     }
 
-    async fn time_left(now_playing_item: &Value, session: &Value) -> Option<i64> {
-        if !session["PlayState"]["IsPaused"].as_bool()? {
+    async fn time_left(now_playing_item: &Value, play_state: &Value) -> Option<i64> {
+        if !play_state["IsPaused"].as_bool()? {
             let ticks_to_seconds = 10000000;
 
-            let mut position_ticks = session["PlayState"]["PositionTicks"].as_i64().unwrap_or(0);
+            let mut position_ticks = play_state["PositionTicks"].as_i64().unwrap_or(0);
             position_ticks /= ticks_to_seconds;
 
             let mut runtime_ticks = now_playing_item["RunTimeTicks"].as_i64().unwrap_or(0);
@@ -395,6 +411,7 @@ pub enum MediaType {
     Episode,
     LiveTv,
     Music,
+    Book,
     AudioBook,
     None,
 }
@@ -409,6 +426,7 @@ impl Serialize for MediaType {
             MediaType::Episode => serializer.serialize_unit_variant("MediaType", 1, "Episode"),
             MediaType::LiveTv => serializer.serialize_unit_variant("MediaType", 2, "LiveTv"),
             MediaType::Music => serializer.serialize_unit_variant("MediaType", 3, "Music"),
+            MediaType::Book => serializer.serialize_unit_variant("MediaType", 4, "Book"),
             MediaType::AudioBook => serializer.serialize_unit_variant("MediaType", 4, "AudioBook"),
             MediaType::None => serializer.serialize_unit_variant("MediaType", 5, "None"),
         }
@@ -462,6 +480,7 @@ impl std::fmt::Display for MediaType {
             MediaType::LiveTv => "LiveTv",
             MediaType::Movie => "Movie",
             MediaType::Music => "Music",
+            MediaType::Book => "Book",
             MediaType::AudioBook => "AudioBook",
             MediaType::None => "None",
         };
@@ -488,6 +507,7 @@ impl From<&'static str> for MediaType {
             "movie" => Self::Movie,
             "music" => Self::Music,
             "livetv" => Self::LiveTv,
+            "book" => Self::Book,
             "audiobook" => Self::AudioBook,
             _ => Self::None,
         }
@@ -501,6 +521,7 @@ impl From<String> for MediaType {
             "movie" => Self::Movie,
             "music" => Self::Music,
             "livetv" => Self::LiveTv,
+            "book" => Self::Book,
             "audiobook" => Self::AudioBook,
             _ => Self::None,
         }


### PR DESCRIPTION
Changed `setactivity()` to account for no runtime.
Created new `MediaType::Book`, implemented into serialize, deserialize and from.
Updated README with new book type.
Version bump to 0.15.0

![example image](https://user-images.githubusercontent.com/66682497/267392922-0a37013f-5fba-43fc-afa4-ba67baf2509d.png)