### PR TITLE
Fix subsprocess call missing round brackets on the installer

### DIFF
--- a/scripts/installer.py
+++ b/scripts/installer.py
@@ -211,7 +211,7 @@ if platform.system() == "Windows":
         if os.path.isfile(path + "winsw.exe"):
             print("The script will prompt for administrator to remove the already installed service")
             sleep(1)
-            subprocess.run[path + "winsw.exe", "uninstall"]
+            subprocess.run([path + "winsw.exe", "uninstall"])
 
         subprocess.run(["curl", "-o", path + "winsw.exe", "-L", "https://github.com/winsw/winsw/releases/latest/download/WinSW-x64.exe"])
 


### PR DESCRIPTION
I tried reinstalling the project on Windows yesterday but got `TypeError: 'function' object is not subscriptable`. I looked at the source code, and it turned out there's a missing round bracket when calling `subprocess.run`.

This PR fixes it by adding the missing round brackets.