### PR TITLE
Fixed content that doesnt have images

### DIFF
--- a/src/services/jellyfin.rs
+++ b/src/services/jellyfin.rs
@@ -140,7 +140,7 @@ impl Content {
                 .and_then(|images| images.enable_images)
                 .unwrap_or(false)
             {
-                image_url = Content::image(&config.jellyfin.url, content.item_id.clone()).await;
+                image_url = Content::image(&config.jellyfin.url, content.item_id.clone()).await.unwrap_or(String::from(""));
             }
 
             content.external_services(ExternalServices::get(now_playing_item).await);
@@ -344,12 +344,18 @@ impl Content {
         state
     }
 
-    async fn image(url: &str, item_id: String) -> String {
-        format!(
+    async fn image(url: &str, item_id: String) -> Result<String, reqwest::Error> {
+        let img = format!(
             "{}/Items/{}/Images/Primary",
             url.trim_end_matches('/'),
             item_id
-        )
+        );
+
+        if reqwest::get(&img).await?.text().await.unwrap_or(String::from("_")).contains("does not have an image of type Primary") {
+            Ok(String::from(""))
+        } else {
+            Ok(img)
+        }
     }
 
     fn get_genres(npi: &Value) -> Option<String> {


### PR DESCRIPTION
Before it would just break and try to display the image anyways, now it checks if the URL is returning an image or just some text before it tries displaying it.