### PR TITLE
Add documentation for rustdoc

### DIFF
--- a/jellyfin-rpc-cli/src/main.rs
+++ b/jellyfin-rpc-cli/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use colored::Colorize;
 use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
-pub use jellyfin_rpc::imgur::*;
+pub use jellyfin_rpc::services::imgur::*;
 pub use jellyfin_rpc::prelude::*;
 use retry::retry_with_index;
 #[cfg(feature = "updates")]

--- a/jellyfin-rpc/src/core/config.rs
+++ b/jellyfin-rpc/src/core/config.rs
@@ -4,73 +4,124 @@ use serde::{Deserialize, Serialize};
 use serde_json;
 use std::env;
 
+/// Main struct containing every other struct in the file.
+/// 
+/// The config file is parsed into this struct.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub struct Config {
+    /// Jellyfin configuration.
+    /// 
+    /// Has every required part of the config, hence why its not an `Option<Jellyfin>`.
     pub jellyfin: Jellyfin,
+    /// Discord configuration.
     pub discord: Option<Discord>,
+    /// Imgur configuration.
     pub imgur: Option<Imgur>,
+    /// Images configuration.
     pub images: Option<Images>,
 }
 
+/// This struct contains every "required" part of the config.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Jellyfin {
+    /// URL to the jellyfin server.
     pub url: String,
+    /// Api key from the jellyfin server, used to gather what's being watched.
     pub api_key: String,
+    /// Username of the person that info should be gathered from.
     pub username: Username,
+    /// Contains configuration for Music display.
     pub music: Option<Music>,
+    /// Blacklist configuration.
     pub blacklist: Option<Blacklist>,
 }
 
+/// Username of the person that info should be gathered from.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum Username {
+    /// If the username is a `Vec<String>`.
     Vec(Vec<String>),
+    /// If the username is a `String`.
     String(String),
 }
 
+/// Contains configuration for Music display.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Music {
+    /// Display is where you tell the program what should be displayed.
+    /// 
+    /// Example: `vec![String::from("genres"), String::from("year")]`
     pub display: Option<Display>,
+    /// Separator is what should be between the artist(s) and the `display` options.
     pub separator: Option<char>,
 }
 
+/// Display is where you tell the program what should be displayed.
+/// 
+/// Example: `vec![String::from("genres"), String::from("year")]`
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum Display {
+    /// If the Display is a `Vec<String>`.
     Vec(Vec<String>),
+    /// If the Display is a comma separated `String`.
     String(String),
 }
 
+/// Blacklist MediaTypes and libraries.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Blacklist {
+    /// `Vec<String>` of MediaTypes to blacklist
     pub media_types: Option<Vec<MediaType>>,
+    /// `Vec<String>` of libraries to blacklist
     pub libraries: Option<Vec<String>>,
 }
 
+/// Discord configuration
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Discord {
+    /// Set a custom Application ID to be used.
     pub application_id: Option<String>,
+    /// Set custom buttons to be displayed.
     pub buttons: Option<Vec<Button>>,
 }
 
+/// Button struct
+/// 
+/// Contains information about buttons
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Button {
+    /// What the name should be showed as in Discord.
     pub name: String,
+    /// What clicking it should point to in Discord.
     pub url: String,
 }
 
+/// Imgur configuration
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Imgur {
+    /// Contains the client ID used to upload images to imgur.
     pub client_id: Option<String>,
 }
 
+/// Images configuration
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Images {
+    /// Enables images, not everyone wants them so its a toggle.
     pub enable_images: Option<bool>,
+    /// Enables imgur images.
     pub imgur_images: Option<bool>,
 }
 
+/// Find config.json in filesystem.
+/// 
+/// This is to avoid the user having to specify a filepath on launch.
+/// 
+/// Default config path depends on OS
+/// Windows: `%appdata%\jellyfin-rpc\config.json`
+/// Linux/macOS: `~/.config/jellyfin-rpc/config.json`
 pub fn get_config_path() -> Result<String, ConfigError> {
     if cfg!(not(windows)) {
         let xdg_config_home = match env::var("XDG_CONFIG_HOME") {

--- a/jellyfin-rpc/src/core/error.rs
+++ b/jellyfin-rpc/src/core/error.rs
@@ -1,10 +1,15 @@
 use std::env;
 
+/// Error type for the config module.
 #[derive(Debug)]
 pub enum ConfigError {
+    /// Returns when it can't find the config file.
     MissingConfig(String),
+    /// Returns when it can't read the config file.
     Io(String),
+    /// Returns when it's unable to parse the config file to the Config struct.
     Json(String),
+    /// Returns when environment variables fail to be read.
     VarError(String),
 }
 
@@ -32,13 +37,22 @@ impl From<env::VarError> for ConfigError {
     }
 }
 
+/// Error type for the imgur module.
 #[derive(Debug)]
 pub enum ImgurError {
+    /// Returns when the response from the Imgur API is invalid.
+    ///
+    /// This is usually due to a bad API key or something wrong with the image its trying to upload.
     InvalidResponse,
+    /// Returns on errors in the reqwest library, can happen when trying to upload a file.
     Reqwest(String),
+    /// Returns when it can't read the urls.json file.
     Io(String),
+    /// Returns when it can't parse the urls.json file.
     Json(String),
+    /// Returns when environment variables fail to be read.
     VarError(String),
+    /// Returns when a required `Option<T>` is `None`.
     None,
 }
 
@@ -66,9 +80,13 @@ impl From<env::VarError> for ImgurError {
     }
 }
 
+/// Error type for the jellyfin module
+// TODO: Rename to `JellyfinError`
 #[derive(Debug)]
 pub enum ContentError {
+    /// Returns on errors in the reqwest library, can happen when trying to access the Jellyfin server.
     Reqwest(reqwest::Error, String),
+    /// Returns when the reply from jellyfin can't be parsed to the needed types.
     Json(serde_json::Error),
 }
 

--- a/jellyfin-rpc/src/core/mod.rs
+++ b/jellyfin-rpc/src/core/mod.rs
@@ -1,3 +1,5 @@
+/// Module for config.json file
 pub mod config;
+/// Module containing error types used by the library.
 pub mod error;
 pub(crate) mod rpc;

--- a/jellyfin-rpc/src/core/rpc.rs
+++ b/jellyfin-rpc/src/core/rpc.rs
@@ -1,6 +1,9 @@
 use crate::prelude::MediaType;
 use discord_rich_presence::activity;
 
+/// Used to set the activity on Discord.
+/// 
+/// This has checks to do different things for different mediatypes and replaces images with default ones if they are needed.
 pub fn setactivity<'a>(
     state_message: &'a String,
     details: &'a str,

--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -3,6 +3,8 @@
 /// Main module
 pub mod core;
 /// Useful imports
+/// 
+/// Contains imports that most programs will be using.
 pub mod prelude;
 /// External connections
 pub mod services;
@@ -13,6 +15,7 @@ use retry::retry_with_index;
 pub use core::rpc::setactivity;
 
 #[cfg(not(feature = "cli"))]
+/// Function for connecting to the Discord Ipc.
 pub fn connect(rich_presence_client: &mut DiscordIpcClient) {
     retry_with_index(
         retry::delay::Exponential::from_millis(1000),
@@ -25,6 +28,7 @@ pub fn connect(rich_presence_client: &mut DiscordIpcClient) {
 }
 
 #[cfg(feature = "cli")]
+/// Function for connecting to the Discord Ipc.
 pub fn connect(rich_presence_client: &mut DiscordIpcClient) {
     use colored::Colorize;
     println!(

--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -1,11 +1,15 @@
+//! Backend for displaying jellyfin rich presence on discord
+
+/// Main module
+pub mod core;
+/// Useful imports
 pub mod prelude;
+/// External connections
 pub mod services;
 pub use crate::core::error;
-pub use crate::services::imgur;
 use discord_rich_presence::DiscordIpc;
 use discord_rich_presence::DiscordIpcClient;
 use retry::retry_with_index;
-pub mod core;
 pub use core::rpc::setactivity;
 
 #[cfg(not(feature = "cli"))]

--- a/jellyfin-rpc/src/services/imgur.rs
+++ b/jellyfin-rpc/src/services/imgur.rs
@@ -7,11 +7,13 @@ use std::{env, fs, path};
     TODO: Comments
 */
 
+/// Struct containing the Imgur URL of the currently playing item.
 #[derive(Default)]
 pub struct Imgur {
     pub url: String,
 }
 
+/// Find urls.json in filesystem, used to store images that were already previously uploaded to imgur.
 pub fn get_urls_path() -> Result<String, ImgurError> {
     if cfg!(not(windows)) {
         let xdg_config_home = match env::var("XDG_CONFIG_HOME") {
@@ -27,6 +29,9 @@ pub fn get_urls_path() -> Result<String, ImgurError> {
 }
 
 impl Imgur {
+    /// Queries the urls.json file for an imgur url with the same item ID attached.
+    /// 
+    /// If there's no imgur URL in the file, it will upload the image to imgur, store it in the file and then hand the URL over in a result.
     pub async fn get(
         image_url: &str,
         item_id: &str,

--- a/jellyfin-rpc/src/services/imgur.rs
+++ b/jellyfin-rpc/src/services/imgur.rs
@@ -3,10 +3,6 @@ use serde_json::{json, Value};
 use std::io::Write;
 use std::{env, fs, path};
 
-/*
-    TODO: Comments
-*/
-
 /// Struct containing the Imgur URL of the currently playing item.
 #[derive(Default)]
 pub struct Imgur {
@@ -14,6 +10,12 @@ pub struct Imgur {
 }
 
 /// Find urls.json in filesystem, used to store images that were already previously uploaded to imgur.
+/// 
+/// This is to avoid the user having to specify a filepath on launch.
+/// 
+/// Default urls.json path depends on OS
+/// Windows: `%appdata%\jellyfin-rpc\urls.json`
+/// Linux/macOS: `~/.config/jellyfin-rpc/urls.json`
 pub fn get_urls_path() -> Result<String, ImgurError> {
     if cfg!(not(windows)) {
         let xdg_config_home = match env::var("XDG_CONFIG_HOME") {

--- a/jellyfin-rpc/src/services/jellyfin.rs
+++ b/jellyfin-rpc/src/services/jellyfin.rs
@@ -92,6 +92,11 @@ pub struct Content {
 }
 
 impl Content {
+    /// Calls the Content::get() function recursively until it returns a Content struct.
+    /// 
+    /// It waits (attempt * 5) seconds before retrying.
+    /// 
+    /// The max time it will wait is 30 seconds.
     #[async_recursion]
     pub async fn try_get(config: &Config, attempt: u64) -> Self {
         let mut time = attempt * 5;
@@ -114,6 +119,7 @@ impl Content {
         }
     }
 
+    /// Returns a Content struct with the updated information from jellyfin
     pub async fn get(config: &Config) -> Result<Self, ContentError> {
         let sessions: Vec<Value> = serde_json::from_str(
             &reqwest::get(format!(
@@ -433,9 +439,16 @@ impl Content {
     }
 }
 
+/// Struct with the external services collected from Jellyfin.
 #[derive(Debug, Clone)]
 pub struct ExternalServices {
+    /// Name of the service
+    /// 
+    /// Example: IMDb, Trakt
     pub name: String,
+    /// URL pointing to the specific Show/Movie etc. on the external service.
+    /// 
+    /// Example: <https://www.imdb.com/title/tt0117500/>, <https://trakt.tv/shows/the-simpsons>
     pub url: String,
 }
 
@@ -468,14 +481,22 @@ impl ExternalServices {
     }
 }
 
+/// The type of the currently playing content.
 #[derive(Debug, PartialEq, Clone)]
 pub enum MediaType {
+    /// If the content playing is a Movie.
     Movie,
+    /// If the content playing is an Episode.
     Episode,
+    /// If the content playing is a LiveTv.
     LiveTv,
+    /// If the content playing is a Music.
     Music,
+    /// If the content playing is a Book.
     Book,
+    /// If the content playing is an Audio Book.
     AudioBook,
+    /// If nothing is playing.
     None,
 }
 
@@ -558,6 +579,7 @@ impl Default for MediaType {
 }
 
 impl MediaType {
+    /// Check if the MediaType is none, returns `true` if it is.
     pub fn is_none(&self) -> bool {
         self == &Self::None
     }

--- a/jellyfin-rpc/src/services/jellyfin.rs
+++ b/jellyfin-rpc/src/services/jellyfin.rs
@@ -4,10 +4,6 @@ use async_recursion::async_recursion;
 use serde::{de::Visitor, Deserialize, Serialize};
 use serde_json::Value;
 
-/*
-    TODO: Comments
-*/
-
 #[derive(Default, Clone)]
 struct ContentBuilder {
     media_type: MediaType,

--- a/jellyfin-rpc/src/services/jellyfin.rs
+++ b/jellyfin-rpc/src/services/jellyfin.rs
@@ -65,14 +65,29 @@ impl ContentBuilder {
     }
 }
 
+/// Struct containing information about what's being played on jellyfin
 #[derive(Default)]
 pub struct Content {
+    /// What type of content is currently playing.
+    /// 
+    /// Example: MediaType::Movie
     pub media_type: MediaType,
+    /// The title of the content
     pub details: String,
+    /// Description of the content, usually includes season and episode/genres, etc.
     pub state_message: String,
+    /// When the content will end, current UNIX epoch + time left
     pub endtime: Option<i64>,
+    /// Image URL supplied by Jellyfin, this is different from the Imgur URL
+    /// 
+    /// This has to be passed to the Imgur::get() function to upload images to imgur
     pub image_url: String,
+    /// Item ID of the content currently playing, 
+    /// used to store Imgur URLs so that they can be reused instead of reuploading to Imgur every time.
     pub item_id: String,
+    /// External services to display as buttons.
+    /// 
+    /// Example: IMDb, Trakt, etc.
     pub external_services: Vec<ExternalServices>,
 }
 

--- a/jellyfin-rpc/src/services/mod.rs
+++ b/jellyfin-rpc/src/services/mod.rs
@@ -1,3 +1,5 @@
 #[cfg(feature = "imgur")]
+/// Upload and store images on imgur
 pub mod imgur;
+/// Gather info from Jellyfin
 pub mod jellyfin;


### PR DESCRIPTION
Add documentation for rustdoc so that the jellyfin-rpc crate isn't so barren on https://docs.rs/