### PR TITLE
Add support for self signed certificates (#85)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,23 +471,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jellyfin-rpc"
-version = "0.1.4"
-dependencies = [
- "async-recursion",
- "colored",
- "discord-rich-presence",
- "reqwest",
- "retry",
- "serde",
- "serde_json",
- "tokio",
-]
-
-[[package]]
-name = "jellyfin-rpc"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856f3991e7242adf39b63489d431f3186749579df17f0b4fedd0916de46ae6e9"
+version = "0.1.5"
 dependencies = [
  "async-recursion",
  "colored",
@@ -501,12 +485,12 @@ dependencies = [
 
 [[package]]
 name = "jellyfin-rpc-cli"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "clap",
  "colored",
  "discord-rich-presence",
- "jellyfin-rpc 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jellyfin-rpc",
  "reqwest",
  "retry",
  "tokio",

--- a/example.json
+++ b/example.json
@@ -7,6 +7,7 @@
             "display": "genres",
             "separator": "-"
         },
+        "self_signed_cert": false,
         "_comment": "the 4 lines below and this line arent needed and should be removed, by default nothing will display if these are present",
         "blacklist": {
             "media_types": ["music", "movie", "episode", "livetv"],

--- a/jellyfin-rpc-cli/Cargo.toml
+++ b/jellyfin-rpc-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "jellyfin-rpc-cli"
-version      = "0.15.4"
+version      = "0.15.5"
 edition      = "2021"
 description  = "Displays the content you're currently watching on Discord!"
 license      = "GPL-3.0-or-later"
@@ -27,8 +27,8 @@ retry                 = "2.0"
 
 [dependencies.jellyfin-rpc]
 features = ["imgur", "cli"]
-version  = "0.1.4"
-#path = "../jellyfin-rpc"
+#version  = "0.1.4"
+path = "../jellyfin-rpc"
 
 [dependencies.clap]
 features = ["derive"]

--- a/jellyfin-rpc/Cargo.toml
+++ b/jellyfin-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "jellyfin-rpc"
-version     = "0.1.4"
+version     = "0.1.5"
 edition     = "2021"
 description = "Backend for the Jellyfin-RPC-cli and Jellyfin-RPC-Iced projects"
 license     = "GPL-3.0-or-later"

--- a/jellyfin-rpc/example.json
+++ b/jellyfin-rpc/example.json
@@ -7,6 +7,7 @@
             "display": "genres",
             "separator": "-"
         },
+        "self_signed_cert": false,
         "_comment": "the 4 lines below and this line arent needed and should be removed, by default nothing will display if these are present",
         "blacklist": {
             "media_types": ["music", "movie", "episode", "livetv"],

--- a/jellyfin-rpc/src/core/config.rs
+++ b/jellyfin-rpc/src/core/config.rs
@@ -5,13 +5,13 @@ use serde_json;
 use std::env;
 
 /// Main struct containing every other struct in the file.
-/// 
+///
 /// The config file is parsed into this struct.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub struct Config {
     /// Jellyfin configuration.
-    /// 
+    ///
     /// Has every required part of the config, hence why its not an `Option<Jellyfin>`.
     pub jellyfin: Jellyfin,
     /// Discord configuration.
@@ -35,6 +35,8 @@ pub struct Jellyfin {
     pub music: Option<Music>,
     /// Blacklist configuration.
     pub blacklist: Option<Blacklist>,
+    /// Self signed certificate option
+    pub self_signed_cert: Option<bool>,
 }
 
 /// Username of the person that info should be gathered from.
@@ -51,7 +53,7 @@ pub enum Username {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Music {
     /// Display is where you tell the program what should be displayed.
-    /// 
+    ///
     /// Example: `vec![String::from("genres"), String::from("year")]`
     pub display: Option<Display>,
     /// Separator is what should be between the artist(s) and the `display` options.
@@ -59,7 +61,7 @@ pub struct Music {
 }
 
 /// Display is where you tell the program what should be displayed.
-/// 
+///
 /// Example: `vec![String::from("genres"), String::from("year")]`
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
@@ -89,7 +91,7 @@ pub struct Discord {
 }
 
 /// Button struct
-/// 
+///
 /// Contains information about buttons
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Button {
@@ -116,9 +118,9 @@ pub struct Images {
 }
 
 /// Find config.json in filesystem.
-/// 
+///
 /// This is to avoid the user having to specify a filepath on launch.
-/// 
+///
 /// Default config path depends on OS
 /// Windows: `%appdata%\jellyfin-rpc\config.json`
 /// Linux/macOS: `~/.config/jellyfin-rpc/config.json`
@@ -154,6 +156,7 @@ impl Default for Config {
                 api_key: "".to_string(),
                 music: None,
                 blacklist: None,
+                self_signed_cert: None,
             },
             discord: None,
             imgur: None,

--- a/jellyfin-rpc/src/core/rpc.rs
+++ b/jellyfin-rpc/src/core/rpc.rs
@@ -2,7 +2,7 @@ use crate::prelude::MediaType;
 use discord_rich_presence::activity;
 
 /// Used to set the activity on Discord.
-/// 
+///
 /// This has checks to do different things for different mediatypes and replaces images with default ones if they are needed.
 pub fn setactivity<'a>(
     state_message: &'a str,

--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -61,3 +61,13 @@ pub fn connect(rich_presence_client: &mut DiscordIpcClient) {
     )
     .unwrap();
 }
+
+/// Built in reqwest::get() function, has an extra field to specify if the self signed cert should be accepted.
+pub async fn get<U: reqwest::IntoUrl>(url: U, self_signed_cert: bool) -> Result<reqwest::Response, reqwest::Error> {
+    reqwest::Client::builder()
+        .danger_accept_invalid_certs(self_signed_cert)
+        .build()?
+        .get(url)
+        .send()
+        .await
+}

--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -63,7 +63,10 @@ pub fn connect(rich_presence_client: &mut DiscordIpcClient) {
 }
 
 /// Built in reqwest::get() function, has an extra field to specify if the self signed cert should be accepted.
-pub async fn get<U: reqwest::IntoUrl>(url: U, self_signed_cert: bool) -> Result<reqwest::Response, reqwest::Error> {
+pub async fn get<U: reqwest::IntoUrl>(
+    url: U,
+    self_signed_cert: bool,
+) -> Result<reqwest::Response, reqwest::Error> {
     reqwest::Client::builder()
         .danger_accept_invalid_certs(self_signed_cert)
         .build()?

--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -3,16 +3,16 @@
 /// Main module
 pub mod core;
 /// Useful imports
-/// 
+///
 /// Contains imports that most programs will be using.
 pub mod prelude;
 /// External connections
 pub mod services;
 pub use crate::core::error;
+pub use core::rpc::setactivity;
 use discord_rich_presence::DiscordIpc;
 use discord_rich_presence::DiscordIpcClient;
 use retry::retry_with_index;
-pub use core::rpc::setactivity;
 #[cfg(test)]
 mod tests;
 

--- a/jellyfin-rpc/src/services/imgur.rs
+++ b/jellyfin-rpc/src/services/imgur.rs
@@ -120,12 +120,7 @@ impl Imgur {
         client_id: &str,
         self_signed_cert: bool,
     ) -> Result<String, ImgurError> {
-        let img = reqwest::Client::builder()
-            .danger_accept_invalid_certs(self_signed_cert)
-            .build()
-            .unwrap()
-            .get(image_url)
-            .send()
+        let img = crate::get(image_url, self_signed_cert)
             .await?
             .bytes()
             .await?;

--- a/jellyfin-rpc/src/services/imgur.rs
+++ b/jellyfin-rpc/src/services/imgur.rs
@@ -10,9 +10,9 @@ pub struct Imgur {
 }
 
 /// Find urls.json in filesystem, used to store images that were already previously uploaded to imgur.
-/// 
+///
 /// This is to avoid the user having to specify a filepath on launch.
-/// 
+///
 /// Default urls.json path depends on OS
 /// Windows: `%appdata%\jellyfin-rpc\urls.json`
 /// Linux/macOS: `~/.config/jellyfin-rpc/urls.json`
@@ -32,13 +32,14 @@ pub fn get_urls_path() -> Result<String, ImgurError> {
 
 impl Imgur {
     /// Queries the urls.json file for an imgur url with the same item ID attached.
-    /// 
+    ///
     /// If there's no imgur URL in the file, it will upload the image to imgur, store it in the file and then hand the URL over in a result.
     pub async fn get(
         image_url: &str,
         item_id: &str,
         client_id: &str,
         image_urls_file: Option<String>,
+        self_signed_cert: bool,
     ) -> Result<Self, ImgurError> {
         let file = match image_urls_file {
             Some(file) => file,
@@ -53,7 +54,15 @@ impl Imgur {
         }
 
         Ok(Self {
-            url: Imgur::write_file(file, image_url, item_id, client_id, &mut json).await?,
+            url: Imgur::write_file(
+                file,
+                image_url,
+                item_id,
+                client_id,
+                self_signed_cert,
+                &mut json,
+            )
+            .await?,
         })
     }
 
@@ -87,12 +96,13 @@ impl Imgur {
         image_url: &str,
         item_id: &str,
         client_id: &str,
+        self_signed_cert: bool,
         json: &mut Value,
     ) -> Result<String, ImgurError> {
         // Create a new map that's used for adding data to the "urls.json" file
         let mut new_data = serde_json::Map::new();
         // Upload the content's image to imgur
-        let imgur_url = Imgur::upload(image_url, client_id).await?;
+        let imgur_url = Imgur::upload(image_url, client_id, self_signed_cert).await?;
         // Insert the item_id and the new image url into the map we created earlier
         new_data.insert(item_id.to_string(), json!(imgur_url));
 
@@ -105,8 +115,20 @@ impl Imgur {
         Ok(imgur_url)
     }
 
-    async fn upload(image_url: &str, client_id: &str) -> Result<String, ImgurError> {
-        let img = reqwest::get(image_url).await?.bytes().await?;
+    async fn upload(
+        image_url: &str,
+        client_id: &str,
+        self_signed_cert: bool,
+    ) -> Result<String, ImgurError> {
+        let img = reqwest::Client::builder()
+            .danger_accept_invalid_certs(self_signed_cert)
+            .build()
+            .unwrap()
+            .get(image_url)
+            .send()
+            .await?
+            .bytes()
+            .await?;
         let client = reqwest::Client::new();
         let response = client
             .post("https://api.imgur.com/3/image")

--- a/jellyfin-rpc/src/services/jellyfin.rs
+++ b/jellyfin-rpc/src/services/jellyfin.rs
@@ -65,7 +65,7 @@ impl ContentBuilder {
 #[derive(Default)]
 pub struct Content {
     /// What type of content is currently playing.
-    /// 
+    ///
     /// Example: MediaType::Movie
     pub media_type: MediaType,
     /// The title of the content
@@ -75,23 +75,23 @@ pub struct Content {
     /// When the content will end, current UNIX epoch + time left
     pub endtime: Option<i64>,
     /// Image URL supplied by Jellyfin, this is different from the Imgur URL
-    /// 
+    ///
     /// This has to be passed to the Imgur::get() function to upload images to imgur
     pub image_url: String,
-    /// Item ID of the content currently playing, 
+    /// Item ID of the content currently playing,
     /// used to store Imgur URLs so that they can be reused instead of reuploading to Imgur every time.
     pub item_id: String,
     /// External services to display as buttons.
-    /// 
+    ///
     /// Example: IMDb, Trakt, etc.
     pub external_services: Vec<ExternalServices>,
 }
 
 impl Content {
     /// Calls the Content::get() function recursively until it returns a Content struct.
-    /// 
+    ///
     /// It waits (attempt * 5) seconds before retrying.
-    /// 
+    ///
     /// The max time it will wait is 30 seconds.
     #[async_recursion]
     pub async fn try_get(config: &Config, attempt: u64) -> Self {
@@ -118,6 +118,21 @@ impl Content {
     /// Returns a Content struct with the updated information from jellyfin
     pub async fn get(config: &Config) -> Result<Self, ContentError> {
         let sessions: Vec<Value> = serde_json::from_str(
+            &reqwest::Client::builder()
+                .danger_accept_invalid_certs(config.jellyfin.self_signed_cert.unwrap_or(false))
+                .build()
+                .unwrap()
+                .get(format!(
+                    "{}/Sessions?api_key={}",
+                    config.jellyfin.url.trim_end_matches('/'),
+                    config.jellyfin.api_key
+                ))
+                .send()
+                .await?
+                .text()
+                .await?,
+        )?;
+        /*let sessions: Vec<Value> = serde_json::from_str(
             &reqwest::get(format!(
                 "{}/Sessions?api_key={}",
                 config.jellyfin.url.trim_end_matches('/'),
@@ -126,7 +141,7 @@ impl Content {
             .await?
             .text()
             .await?,
-        )?;
+        )?;*/
         for session in sessions {
             if session.get("UserName").is_none() {
                 continue;
@@ -175,9 +190,13 @@ impl Content {
                 .and_then(|images| images.enable_images)
                 .unwrap_or(false)
             {
-                image_url = Content::image(&config.jellyfin.url, content.item_id.clone())
-                    .await
-                    .unwrap_or(String::from(""));
+                image_url = Content::image(
+                    &config.jellyfin.url,
+                    content.item_id.clone(),
+                    config.jellyfin.self_signed_cert.unwrap_or(false),
+                )
+                .await
+                .unwrap_or(String::from(""));
             }
 
             content.external_services(ExternalServices::get(now_playing_item).await);
@@ -395,14 +414,23 @@ impl Content {
         state
     }
 
-    async fn image(url: &str, item_id: String) -> Result<String, reqwest::Error> {
+    async fn image(
+        url: &str,
+        item_id: String,
+        self_signed_cert: bool,
+    ) -> Result<String, reqwest::Error> {
         let img = format!(
             "{}/Items/{}/Images/Primary",
             url.trim_end_matches('/'),
             item_id
         );
 
-        if reqwest::get(&img)
+        if reqwest::Client::builder()
+            .danger_accept_invalid_certs(self_signed_cert)
+            .build()
+            .unwrap()
+            .get(&img)
+            .send()
             .await?
             .text()
             .await
@@ -439,11 +467,11 @@ impl Content {
 #[derive(Debug, Clone)]
 pub struct ExternalServices {
     /// Name of the service
-    /// 
+    ///
     /// Example: IMDb, Trakt
     pub name: String,
     /// URL pointing to the specific Show/Movie etc. on the external service.
-    /// 
+    ///
     /// Example: <https://www.imdb.com/title/tt0117500/>, <https://trakt.tv/shows/the-simpsons>
     pub url: String,
 }
@@ -616,17 +644,23 @@ pub async fn library_check(
     api_key: &str,
     item_id: &str,
     library: &str,
+    self_signed_cert: bool,
 ) -> Result<bool, Box<dyn std::error::Error>> {
     let parents: Vec<Value> = serde_json::from_str(
-        &reqwest::get(format!(
-            "{}/Items/{}/Ancestors?api_key={}",
-            url.trim_end_matches('/'),
-            item_id,
-            api_key
-        ))
-        .await?
-        .text()
-        .await?,
+        &reqwest::Client::builder()
+            .danger_accept_invalid_certs(self_signed_cert)
+            .build()
+            .unwrap()
+            .get(format!(
+                "{}/Items/{}/Ancestors?api_key={}",
+                url.trim_end_matches('/'),
+                item_id,
+                api_key
+            ))
+            .send()
+            .await?
+            .text()
+            .await?,
     )?;
 
     for i in parents {

--- a/jellyfin-rpc/src/services/jellyfin.rs
+++ b/jellyfin-rpc/src/services/jellyfin.rs
@@ -118,16 +118,17 @@ impl Content {
     /// Returns a Content struct with the updated information from jellyfin
     pub async fn get(config: &Config) -> Result<Self, ContentError> {
         let sessions: Vec<Value> = serde_json::from_str(
-            &crate::get(format!(
+            &crate::get(
+                format!(
                     "{}/Sessions?api_key={}",
                     config.jellyfin.url.trim_end_matches('/'),
                     config.jellyfin.api_key
                 ),
-                config.jellyfin.self_signed_cert.unwrap_or(false)
+                config.jellyfin.self_signed_cert.unwrap_or(false),
             )
-                .await?
-                .text()
-                .await?,
+            .await?
+            .text()
+            .await?,
         )?;
         for session in sessions {
             if session.get("UserName").is_none() {
@@ -629,15 +630,18 @@ pub async fn library_check(
     self_signed_cert: bool,
 ) -> Result<bool, Box<dyn std::error::Error>> {
     let parents: Vec<Value> = serde_json::from_str(
-        &crate::get(format!(
+        &crate::get(
+            format!(
                 "{}/Items/{}/Ancestors?api_key={}",
                 url.trim_end_matches('/'),
                 item_id,
                 api_key
-            ), self_signed_cert)
-            .await?
-            .text()
-            .await?,
+            ),
+            self_signed_cert,
+        )
+        .await?
+        .text()
+        .await?,
     )?;
 
     for i in parents {

--- a/jellyfin-rpc/src/tests.rs
+++ b/jellyfin-rpc/src/tests.rs
@@ -21,7 +21,7 @@ fn load_example_config() {
                 ]),
                 libraries: Some(vec!["Anime".to_string(), "Anime Movies".to_string()]),
             }),
-            self_signed_cert: None,
+            self_signed_cert: Some(false),
         },
         discord: Some(Discord {
             application_id: Some("1053747938519679018".to_string()),

--- a/jellyfin-rpc/src/tests.rs
+++ b/jellyfin-rpc/src/tests.rs
@@ -1,5 +1,5 @@
+use crate::prelude::{config::*, Content, MediaType};
 use std::env;
-use crate::prelude::{Content, MediaType, config::*};
 
 #[test]
 fn load_example_config() {
@@ -10,22 +10,31 @@ fn load_example_config() {
             username: Username::String("your_username_here".to_string()),
             music: Some(Music {
                 display: Some(Display::String("genres".to_string())),
-                separator: Some('-')
+                separator: Some('-'),
             }),
             blacklist: Some(Blacklist {
-                media_types: Some(vec![MediaType::Music, MediaType::Movie, MediaType::Episode, MediaType::LiveTv]),
-                libraries: Some(vec!["Anime".to_string(), "Anime Movies".to_string()])
-            })
+                media_types: Some(vec![
+                    MediaType::Music,
+                    MediaType::Movie,
+                    MediaType::Episode,
+                    MediaType::LiveTv,
+                ]),
+                libraries: Some(vec!["Anime".to_string(), "Anime Movies".to_string()]),
+            }),
+            self_signed_cert: None,
         },
         discord: Some(Discord {
             application_id: Some("1053747938519679018".to_string()),
-            buttons: Some(vec![Button {
-                name: "dynamic".to_string(),
-                url: "dynamic".to_string()
-            }, Button {
-                name: "dynamic".to_string(),
-                url: "dynamic".to_string()
-            }])
+            buttons: Some(vec![
+                Button {
+                    name: "dynamic".to_string(),
+                    url: "dynamic".to_string(),
+                },
+                Button {
+                    name: "dynamic".to_string(),
+                    url: "dynamic".to_string(),
+                },
+            ]),
         }),
         imgur: Some(Imgur {
             client_id: Some("asdjdjdg394209fdjs093".to_string()),
@@ -33,10 +42,11 @@ fn load_example_config() {
         images: Some(Images {
             enable_images: Some(true),
             imgur_images: Some(true),
-        })
+        }),
     };
 
-    let config = Config::load(&(env::var("CARGO_MANIFEST_DIR").unwrap() + "/example.json")).unwrap();
+    let config =
+        Config::load(&(env::var("CARGO_MANIFEST_DIR").unwrap() + "/example.json")).unwrap();
 
     assert_eq!(example, config);
 }
@@ -50,21 +60,20 @@ fn try_get_content() {
             api_key: "sadasodsapasdskd".to_string(),
             username: Username::String("your_username_here".to_string()),
             music: None,
-            blacklist: None
+            blacklist: None,
+            self_signed_cert: None,
         },
         discord: None,
         imgur: None,
-        images: None
+        images: None,
     };
 
     let rt = tokio::runtime::Builder::new_current_thread()
-    .enable_all()
-    .build()
-    .unwrap();
+        .enable_all()
+        .build()
+        .unwrap();
 
-    rt.block_on(
-        Content::get(&config)
-    ).unwrap();
+    rt.block_on(Content::get(&config)).unwrap();
 }
 
 #[cfg(feature = "imgur")]
@@ -77,9 +86,14 @@ fn try_imgur() {
         .build()
         .unwrap();
 
-    rt.block_on(
-        imgur::Imgur::get("", "", "", Some(env::var("CARGO_MANIFEST_DIR").unwrap() + "/example.json"))
-    ).unwrap();
+    rt.block_on(imgur::Imgur::get(
+        "",
+        "",
+        "",
+        Some(env::var("CARGO_MANIFEST_DIR").unwrap() + "/example.json"),
+        false,
+    ))
+    .unwrap();
 }
 
 #[test]
@@ -87,5 +101,8 @@ fn media_type_is_none() {
     let media_type_1 = MediaType::Movie;
     let media_type_2 = MediaType::None;
 
-    assert_eq!(media_type_1.is_none() == false, media_type_2.is_none() == true)
+    assert_eq!(
+        media_type_1.is_none() == false,
+        media_type_2.is_none() == true
+    )
 }


### PR DESCRIPTION
fixes #85 

Add support for using self signed certificates through a new config option:
```json
{
	"jellyfin": {
		"self_signed_cert": true
	}
}
```


Add `-s`/`--suppress-warnings` so these messages wont show up every time:
![image](https://github.com/Radiicall/jellyfin-rpc/assets/66682497/3ec84a74-3de8-4fc4-a964-e52e0e08bea7)
