### PR TITLE
Add show_paused config option (#102)

### DIFF
--- a/jellyfin-rpc-cli/src/main.rs
+++ b/jellyfin-rpc-cli/src/main.rs
@@ -3,6 +3,7 @@ use colored::Colorize;
 use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
 pub use jellyfin_rpc::prelude::*;
 pub use jellyfin_rpc::services::imgur::*;
+pub use jellyfin_rpc::core::rpc::show_paused;
 use retry::retry_with_index;
 #[cfg(feature = "updates")]
 mod updates;
@@ -206,7 +207,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
 
-        if !content.media_type.is_none() && blacklist_check {
+        if !content.media_type.is_none() && blacklist_check && show_paused(&content.media_type, content.endtime, &config.discord) {
             // Print what we're watching
             if !connected {
                 println!(

--- a/jellyfin-rpc/example.json
+++ b/jellyfin-rpc/example.json
@@ -25,7 +25,8 @@
                 "name": "dynamic",
                 "url": "dynamic"
             }
-        ]
+        ],
+        "show_paused": true
     },
     "imgur": {
         "client_id": "asdjdjdg394209fdjs093"

--- a/jellyfin-rpc/src/core/config.rs
+++ b/jellyfin-rpc/src/core/config.rs
@@ -88,6 +88,8 @@ pub struct Discord {
     pub application_id: Option<String>,
     /// Set custom buttons to be displayed.
     pub buttons: Option<Vec<Button>>,
+    /// Show status when media is paused
+    pub show_paused: Option<bool>,
 }
 
 /// Button struct

--- a/jellyfin-rpc/src/core/mod.rs
+++ b/jellyfin-rpc/src/core/mod.rs
@@ -2,4 +2,4 @@
 pub mod config;
 /// Module containing error types used by the library.
 pub mod error;
-pub(crate) mod rpc;
+pub mod rpc;

--- a/jellyfin-rpc/src/core/rpc.rs
+++ b/jellyfin-rpc/src/core/rpc.rs
@@ -1,4 +1,5 @@
 use crate::prelude::MediaType;
+use super::config::Discord;
 use discord_rich_presence::activity;
 
 /// Used to set the activity on Discord.
@@ -52,4 +53,20 @@ pub fn setactivity<'a>(
     new_activity = new_activity.clone().assets(assets);
 
     new_activity
+}
+
+pub fn show_paused<'a>(media_type: &'a MediaType, endtime: Option<i64>, discord: &'a Option<Discord>) -> bool {
+    if media_type == &MediaType::Book {
+        return true;
+    }
+
+    if endtime.is_some() {
+        return true;
+    }
+
+    if let Some(discord) = discord {
+        return discord.show_paused.unwrap_or(true);
+    }
+
+    true
 }

--- a/jellyfin-rpc/src/tests.rs
+++ b/jellyfin-rpc/src/tests.rs
@@ -35,6 +35,7 @@ fn load_example_config() {
                     url: "dynamic".to_string(),
                 },
             ]),
+            show_paused: Some(true),
         }),
         imgur: Some(Imgur {
             client_id: Some("asdjdjdg394209fdjs093".to_string()),

--- a/scripts/installer.py
+++ b/scripts/installer.py
@@ -145,6 +145,17 @@ if current == "n" or current == "":
     if appid == "":
         appid = None
 
+    show_paused = input("Do you want to show paused videos? (Y/n): ").lower()
+
+    if show_paused == "y":
+        show_paused = True
+    elif show_paused == "n":
+        show_paused = False
+    else:
+        show_paused = None
+
+    print("----------Buttons----------")
+
     while True:
         val = input("Do you want custom buttons? (y/N): ").lower()
 
@@ -220,7 +231,8 @@ if current == "n" or current == "":
 
     discord = {
         "application_id": appid,
-        "buttons": buttons
+        "buttons": buttons,
+        "show_paused": show_paused
     }
 
     config = {


### PR DESCRIPTION
fixes #102 

This will allow you to hide the status when media is paused, it can be configured in the config like this
```json
{
  ...
  "discord": {
    ...
    "show_paused": false
    ...
  }
  ...
}
```