### PR TITLE
Allow more than 2 RPC buttons in the config file

### DIFF
--- a/jellyfin-rpc-cli/src/main.rs
+++ b/jellyfin-rpc-cli/src/main.rs
@@ -270,6 +270,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 } else if button.name != "dynamic" || button.url != "dynamic" {
                     rpcbuttons.push(activity::Button::new(&button.name, &button.url))
                 }
+
+                // Exit early if there's 2 buttons already present, as this is Discord's cap
+                if rpcbuttons.len() == 2 {
+                    break
+                }
             }
 
             rich_presence_client


### PR DESCRIPTION
The title is pretty self explanatory, the loop that parses the buttons will break early whenever it reaches 2 entries.

This allows for stuff like this:
```json
        "buttons": [
            {
                "name": "dynamic",
                "url": "dynamic"
            },
            {
                "name": "dynamic",
                "url": "dynamic"
            },
            {
                "name": "Cool Game :3",
                "url": "https://store.steampowered.com/app/1718240"
            }
        ]
```

Where the 3rd button is only shown if any of the dynamic buttons failed to be created for whatever reason

unsure if this actually needs to be documented anywhere, might be up for discussion