### PR TITLE
ARM support, ommiting episode names and adding a "0" prefix to episode and season numbers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,58 @@ jobs:
           name: linux
           path: target/release/jellyfin-rpc-x86_64-linux
 
+  ubuntu-arm:
+    runs-on: ubuntu-latest
+  
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+  
+      - name: Setup Alpine Linux v3.15 for armv7
+        uses: jirutka/setup-alpine@v1
+        with:
+          arch: armv7
+          branch: v3.15
+          packages: binutils
+  
+      - name: Install latest rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: armv7-unknown-linux-gnueabihf
+          default: true
+          override: true
+  
+      - name: Install arm gcc
+        run: sudo apt install gcc-arm-linux-gnueabihf -y
+  
+      - name: Cache target folder
+        uses: actions/cache@v3
+        env:
+          cache-name: target-folder
+        with:
+          path: target
+          key: arm-linux-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            arm-linux-
+  
+      - name: Build for ARM Linux
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --target armv7-unknown-linux-gnueabihf --workspace --locked --release
+  
+      - name: Strip and rename binary
+        run: strip target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc && mv target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc-arm-linux
+        shell: alpine.sh {0}
+  
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-arm
+          path: target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc-arm-linux
+
   windows:
     runs-on: windows-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
           name: linux
           path: target/release/jellyfin-rpc-x86_64-linux
 
-  ubuntu-arm:
+  ubuntu-arm32:
     runs-on: ubuntu-latest
   
     steps:
@@ -74,7 +74,7 @@ jobs:
           default: true
           override: true
   
-      - name: Install arm gcc
+      - name: Install ARM32 gcc
         run: sudo apt install gcc-arm-linux-gnueabihf -y
   
       - name: Cache target folder
@@ -83,11 +83,11 @@ jobs:
           cache-name: target-folder
         with:
           path: target
-          key: arm-linux-${{ hashFiles('**/Cargo.lock') }}
+          key: arm32-linux-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            arm-linux-
+            arm32-linux-
   
-      - name: Build for ARM Linux
+      - name: Build for ARM32 Linux
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
@@ -95,14 +95,66 @@ jobs:
           args: --target armv7-unknown-linux-gnueabihf --workspace --locked --release
   
       - name: Strip and rename binary
-        run: strip target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc && mv target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc-arm-linux
+        run: strip target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc && mv target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc-arm32-linux
         shell: alpine.sh {0}
   
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: linux-arm
-          path: target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc-arm-linux
+          name: linux-arm32
+          path: target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc-arm32-linux
+
+  ubuntu-arm64:
+    runs-on: ubuntu-latest
+  
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+  
+      - name: Setup Alpine Linux v3.15 for armv7
+        uses: jirutka/setup-alpine@v1
+        with:
+          arch: aarch64
+          branch: v3.15
+          packages: binutils
+  
+      - name: Install latest rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-unknown-linux-gnu
+          default: true
+          override: true
+  
+      - name: Install ARM64 gcc
+        run: sudo apt install gcc-aarch64-linux-gnu -y
+  
+      - name: Cache target folder
+        uses: actions/cache@v3
+        env:
+          cache-name: target-folder
+        with:
+          path: target
+          key: arm64-linux-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            arm64-linux-
+  
+      - name: Build for ARM64 Linux
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --target aarch64-unknown-linux-gnu --workspace --locked --release
+
+      - name: Strip and rename binary
+        run: strip target/aarch64-unknown-linux-gnu/release/jellyfin-rpc && mv target/aarch64-unknown-linux-gnu/release/jellyfin-rpc target/aarch64-unknown-linux-gnu/release/jellyfin-rpc-arm64-linux
+        shell: alpine.sh {0}          
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-arm64
+          path: target/aarch64-unknown-linux-gnu/release/jellyfin-rpc-arm64-linux
 
   windows:
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,13 +59,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
   
-      - name: Setup Alpine Linux v3.15 for armv7
-        uses: jirutka/setup-alpine@v1
-        with:
-          arch: armv7
-          branch: v3.15
-          packages: binutils
-  
       - name: Install latest rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -94,9 +87,8 @@ jobs:
           command: build
           args: --target armv7-unknown-linux-gnueabihf --workspace --locked --release
   
-      - name: Strip and rename binary
-        run: strip target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc && mv target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc-arm32-linux
-        shell: alpine.sh {0}
+      - name: Rename binary
+        run: mv target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc-arm32-linux
   
       - name: Upload artifact
         uses: actions/upload-artifact@v3
@@ -110,13 +102,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-  
-      - name: Setup Alpine Linux v3.15 for armv7
-        uses: jirutka/setup-alpine@v1
-        with:
-          arch: aarch64
-          branch: v3.15
-          packages: binutils
   
       - name: Install latest rust toolchain
         uses: actions-rs/toolchain@v1
@@ -146,9 +131,8 @@ jobs:
           command: build
           args: --target aarch64-unknown-linux-gnu --workspace --locked --release
 
-      - name: Strip and rename binary
-        run: strip target/aarch64-unknown-linux-gnu/release/jellyfin-rpc && mv target/aarch64-unknown-linux-gnu/release/jellyfin-rpc target/aarch64-unknown-linux-gnu/release/jellyfin-rpc-arm64-linux
-        shell: alpine.sh {0}          
+      - name: Rename binary
+        run: mv target/aarch64-unknown-linux-gnu/release/jellyfin-rpc target/aarch64-unknown-linux-gnu/release/jellyfin-rpc-arm64-linux        
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,61 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  ubuntu-arm:
+    runs-on: ubuntu-latest
+  
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+  
+      - name: Setup Alpine Linux v3.15 for armv7
+        uses: jirutka/setup-alpine@v1
+        with:
+          arch: armv7
+          branch: v3.15
+          packages: binutils
+  
+      - name: Install latest rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: armv7-unknown-linux-gnueabihf
+          default: true
+          override: true
+  
+      - name: Install ARM gcc
+        run: sudo apt install gcc-arm-linux-gnueabihf -y
+  
+      - name: Cache target folder
+        uses: actions/cache@v3
+        env:
+          cache-name: target-folder
+        with:
+          path: target
+          key: arm-linux-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            arm-linux-
+  
+      - name: Build for ARM Linux
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --target armv7-unknown-linux-gnueabihf --workspace --locked --release
+  
+      - name: Strip and rename binary
+        run: strip target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc && mv target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc-arm-linux
+        shell: alpine.sh {0}
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc-arm-linux
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   windows:
     runs-on: windows-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,19 +53,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  ubuntu-arm:
+  ubuntu-arm32:
     runs-on: ubuntu-latest
   
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-  
-      - name: Setup Alpine Linux v3.15 for armv7
-        uses: jirutka/setup-alpine@v1
-        with:
-          arch: armv7
-          branch: v3.15
-          packages: binutils
   
       - name: Install latest rust toolchain
         uses: actions-rs/toolchain@v1
@@ -75,7 +68,7 @@ jobs:
           default: true
           override: true
   
-      - name: Install ARM gcc
+      - name: Install ARM32 gcc
         run: sudo apt install gcc-arm-linux-gnueabihf -y
   
       - name: Cache target folder
@@ -84,27 +77,73 @@ jobs:
           cache-name: target-folder
         with:
           path: target
-          key: arm-linux-${{ hashFiles('**/Cargo.lock') }}
+          key: arm32-linux-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            arm-linux-
+            arm32-linux-
   
-      - name: Build for ARM Linux
+      - name: Build for ARM32 Linux
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
           command: build
           args: --target armv7-unknown-linux-gnueabihf --workspace --locked --release
   
-      - name: Strip and rename binary
-        run: strip target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc && mv target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc-arm-linux
-        shell: alpine.sh {0}
+      - name: Rename binary
+        run: mv target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc-arm32-linux
 
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc-arm-linux
+            target/armv7-unknown-linux-gnueabihf/release/jellyfin-rpc-arm32-linux
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  ubuntu-arm64:
+    runs-on: ubuntu-latest
+  
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+  
+      - name: Install latest rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-unknown-linux-gnu
+          default: true
+          override: true
+  
+      - name: Install ARM64 gcc
+        run: sudo apt install gcc-aarch64-linux-gnu -y
+  
+      - name: Cache target folder
+        uses: actions/cache@v3
+        env:
+          cache-name: target-folder
+        with:
+          path: target
+          key: arm64-linux-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            arm64-linux-
+  
+      - name: Build for ARM64 Linux
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --target aarch64-unknown-linux-gnu --workspace --locked --release
+
+      - name: Rename binary
+        run: mv target/aarch64-unknown-linux-gnu/release/jellyfin-rpc target/aarch64-unknown-linux-gnu/release/jellyfin-rpc-arm64-linux  
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            target/aarch64-unknown-linux-gnu/release/jellyfin-rpc-arm64-linux
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/jellyfin-rpc/example.json
+++ b/jellyfin-rpc/example.json
@@ -9,6 +9,7 @@
         },
         "self_signed_cert": false,
         "show_simple": false,
+        "append_prefix": false,
         "_comment": "the 4 lines below and this line arent needed and should be removed, by default nothing will display if these are present",
         "blacklist": {
             "media_types": ["music", "movie", "episode", "livetv"],

--- a/jellyfin-rpc/example.json
+++ b/jellyfin-rpc/example.json
@@ -10,6 +10,7 @@
         "self_signed_cert": false,
         "show_simple": false,
         "append_prefix": false,
+        "add_divider": false,
         "_comment": "the 4 lines below and this line arent needed and should be removed, by default nothing will display if these are present",
         "blacklist": {
             "media_types": ["music", "movie", "episode", "livetv"],

--- a/jellyfin-rpc/example.json
+++ b/jellyfin-rpc/example.json
@@ -8,6 +8,7 @@
             "separator": "-"
         },
         "self_signed_cert": false,
+        "show_simple": false,
         "_comment": "the 4 lines below and this line arent needed and should be removed, by default nothing will display if these are present",
         "blacklist": {
             "media_types": ["music", "movie", "episode", "livetv"],

--- a/jellyfin-rpc/src/core/config.rs
+++ b/jellyfin-rpc/src/core/config.rs
@@ -38,7 +38,9 @@ pub struct Jellyfin {
     /// Self signed certificate option
     pub self_signed_cert: Option<bool>,
     /// Simple episode name
-    pub show_simple: Option<bool>
+    pub show_simple: Option<bool>,
+    /// Add "0" before season/episode number if lower than 10.
+    pub append_prefix: Option<bool>,
 }
 
 /// Username of the person that info should be gathered from.
@@ -170,7 +172,8 @@ impl Default for Config {
                 music: None,
                 blacklist: None,
                 self_signed_cert: None,
-                show_simple: Some(false)
+                show_simple: Some(false),
+                append_prefix: Some(false)
             },
             discord: None,
             imgur: None,

--- a/jellyfin-rpc/src/core/config.rs
+++ b/jellyfin-rpc/src/core/config.rs
@@ -37,6 +37,8 @@ pub struct Jellyfin {
     pub blacklist: Option<Blacklist>,
     /// Self signed certificate option
     pub self_signed_cert: Option<bool>,
+    /// Simple episode name
+    pub show_simple: Option<bool>
 }
 
 /// Username of the person that info should be gathered from.
@@ -168,6 +170,7 @@ impl Default for Config {
                 music: None,
                 blacklist: None,
                 self_signed_cert: None,
+                show_simple: Some(false)
             },
             discord: None,
             imgur: None,

--- a/jellyfin-rpc/src/core/config.rs
+++ b/jellyfin-rpc/src/core/config.rs
@@ -41,6 +41,8 @@ pub struct Jellyfin {
     pub show_simple: Option<bool>,
     /// Add "0" before season/episode number if lower than 10.
     pub append_prefix: Option<bool>,
+    /// Add a divider between numbers
+    pub add_divider: Option<bool>
 }
 
 /// Username of the person that info should be gathered from.
@@ -173,7 +175,8 @@ impl Default for Config {
                 blacklist: None,
                 self_signed_cert: None,
                 show_simple: Some(false),
-                append_prefix: Some(false)
+                append_prefix: Some(false),
+                add_divider: Some(false)
             },
             discord: None,
             imgur: None,

--- a/jellyfin-rpc/src/services/jellyfin.rs
+++ b/jellyfin-rpc/src/services/jellyfin.rs
@@ -233,9 +233,18 @@ impl Content {
             let first_episode_number = now_playing_item["IndexNumber"].as_i64().unwrap_or(0) as i32;
             let mut state;
             if config.jellyfin.append_prefix? {
-                state = format!("S{:02} - E{:02}", season, first_episode_number);
+                if config.jellyfin.add_divider? {
+                  state = format!("S{:02} - E{:02}", season, first_episode_number);
+                } else {
+                  state = format!("S{:02}E{:02}", season, first_episode_number);
+                }
+                
             } else {
+              if config.jellyfin.add_divider? {
                 state = format!("S{} - E{}", season, first_episode_number);
+              } else {
+                state = format!("S{}E{}", season, first_episode_number);
+              }
             };
 
             if season.to_string() == *"null" {

--- a/jellyfin-rpc/src/services/jellyfin.rs
+++ b/jellyfin-rpc/src/services/jellyfin.rs
@@ -223,7 +223,11 @@ impl Content {
         After the for loop is complete we remove the trailing ", " because it looks bad in the presence.
         Then we send it off as a Vec<String> with the external urls and the end timer to the main loop.
         */
-        let name = now_playing_item["Name"].as_str()?;
+        let name = if config.jellyfin.show_simple? {
+          ""
+        } else {
+          now_playing_item["Name"].as_str()?
+        };
         if now_playing_item["Type"].as_str()? == "Episode" {
             let season = now_playing_item["ParentIndexNumber"].to_string();
             let first_episode_number = now_playing_item["IndexNumber"].to_string();
@@ -237,7 +241,9 @@ impl Content {
                 state += &("-".to_string() + &now_playing_item["IndexNumberEnd"].to_string());
             }
 
-            state += &(" ".to_string() + name);
+            if !config.jellyfin.show_simple? {
+              state += &(" ".to_string() + name);
+            }
             content.media_type(MediaType::Episode);
             content.details(now_playing_item["SeriesName"].as_str()?.to_string());
             content.state_message(state);

--- a/jellyfin-rpc/src/tests.rs
+++ b/jellyfin-rpc/src/tests.rs
@@ -22,6 +22,7 @@ fn load_example_config() {
                 libraries: Some(vec!["Anime".to_string(), "Anime Movies".to_string()]),
             }),
             self_signed_cert: Some(false),
+            show_simple: Some(false)
         },
         discord: Some(Discord {
             application_id: Some("1053747938519679018".to_string()),
@@ -63,6 +64,7 @@ fn try_get_content() {
             music: None,
             blacklist: None,
             self_signed_cert: None,
+            show_simple: Some(false)
         },
         discord: None,
         imgur: None,

--- a/jellyfin-rpc/src/tests.rs
+++ b/jellyfin-rpc/src/tests.rs
@@ -22,7 +22,8 @@ fn load_example_config() {
                 libraries: Some(vec!["Anime".to_string(), "Anime Movies".to_string()]),
             }),
             self_signed_cert: Some(false),
-            show_simple: Some(false)
+            show_simple: Some(false),
+            append_prefix: Some(false)
         },
         discord: Some(Discord {
             application_id: Some("1053747938519679018".to_string()),
@@ -64,7 +65,8 @@ fn try_get_content() {
             music: None,
             blacklist: None,
             self_signed_cert: None,
-            show_simple: Some(false)
+            show_simple: Some(false),
+            append_prefix: Some(false)
         },
         discord: None,
         imgur: None,

--- a/jellyfin-rpc/src/tests.rs
+++ b/jellyfin-rpc/src/tests.rs
@@ -23,7 +23,8 @@ fn load_example_config() {
             }),
             self_signed_cert: Some(false),
             show_simple: Some(false),
-            append_prefix: Some(false)
+            append_prefix: Some(false),
+            add_divider: Some(false)
         },
         discord: Some(Discord {
             application_id: Some("1053747938519679018".to_string()),
@@ -66,7 +67,8 @@ fn try_get_content() {
             blacklist: None,
             self_signed_cert: None,
             show_simple: Some(false),
-            append_prefix: Some(false)
+            append_prefix: Some(false),
+            add_divider: Some(false)
         },
         discord: None,
         imgur: None,

--- a/scripts/installer.py
+++ b/scripts/installer.py
@@ -161,6 +161,15 @@ if current == "n" or current == "":
     else:
         append_prefix = False
 
+    add_divider = input("Do you want to add a divider between numbers, ex. S01 - E01? (Y/n): ").lower()
+
+    if add_divider == "y":
+        add_divider = True
+    elif add_divider == "n":
+        add_divider = False
+    else:
+        add_divider = False
+
     jellyfin = {
         "url": url,
         "api_key": api_key,
@@ -169,7 +178,8 @@ if current == "n" or current == "":
         "blacklist": blacklist,
         "self_signed_cert": self_signed_cert,
         "show_simple": show_simple,
-        "append_prefix": append_prefix
+        "append_prefix": append_prefix,
+        "add_divider": add_divider
     }
 
     print("----------Discord----------")

--- a/scripts/installer.py
+++ b/scripts/installer.py
@@ -143,13 +143,23 @@ if current == "n" or current == "":
 
         break
 
+    show_simple = input("Do you want to show episode names in RPC? (Y/n): ").lower()
+
+    if show_simple == "y":
+        show_simple = False
+    elif show_simple == "n":
+        show_simple = True
+    else:
+        show_simple = False
+
     jellyfin = {
         "url": url,
         "api_key": api_key,
         "username": username,
         "music": music,
         "blacklist": blacklist,
-        "self_signed_cert": self_signed_cert
+        "self_signed_cert": self_signed_cert,
+        "show_simple": show_simple
     }
 
     print("----------Discord----------")

--- a/scripts/installer.py
+++ b/scripts/installer.py
@@ -152,6 +152,15 @@ if current == "n" or current == "":
     else:
         show_simple = False
 
+    append_prefix = input("Do you want to add a leading 0 to season and episode numbers? (Y/n): ").lower()
+
+    if append_prefix == "y":
+        append_prefix = True
+    elif append_prefix == "n":
+        append_prefix = False
+    else:
+        append_prefix = False
+
     jellyfin = {
         "url": url,
         "api_key": api_key,
@@ -159,7 +168,8 @@ if current == "n" or current == "":
         "music": music,
         "blacklist": blacklist,
         "self_signed_cert": self_signed_cert,
-        "show_simple": show_simple
+        "show_simple": show_simple,
+        "append_prefix": append_prefix
     }
 
     print("----------Discord----------")

--- a/scripts/installer.py
+++ b/scripts/installer.py
@@ -13,16 +13,7 @@ import sys
 
 
 def is_arm():
-    try:
-        with open('/proc/cpuinfo', 'r') as cpuinfo:
-            for line in cpuinfo:
-                if line.startswith('model name'):
-                    hardware = line.split(':')[1].strip()
-                    if 'ARM' in hardware:
-                        return True
-    except FileNotFoundError:
-        pass
-    return False
+    return True if 'arm' in platform.machine().lower() or 'aarch' in platform.machine().lower() else False
 
 path = ""
 

--- a/scripts/installer.py
+++ b/scripts/installer.py
@@ -11,6 +11,19 @@ import platform
 from time import sleep
 import sys
 
+
+def is_arm():
+    try:
+        with open('/proc/cpuinfo', 'r') as cpuinfo:
+            for line in cpuinfo:
+                if line.startswith('model name'):
+                    hardware = line.split(':')[1].strip()
+                    if 'ARM' in hardware:
+                        return True
+    except FileNotFoundError:
+        pass
+    return False
+
 path = ""
 
 if platform.system() != "Windows":
@@ -359,8 +372,13 @@ elif platform.system() == "Darwin":
         print("If needed, you can run Jellyfin RPC at any time by running 'jellyfin-rpc' in a terminal.")
         break
 else:
+    if is_arm():
+      linux_binary = "jellyfin-rpc-arm-linux"
+    else :
+      linux_binary = "jellyfin-rpc-x86_64-linux"
+
     subprocess.run(["mkdir", "-p", os.environ["HOME"].removesuffix("/") + "/.local/bin"])
-    subprocess.run(["curl", "-o", os.environ["HOME"].removesuffix("/") + "/.local/bin/jellyfin-rpc", "-L", "https://github.com/Radiicall/jellyfin-rpc/releases/latest/download/jellyfin-rpc-x86_64-linux"])
+    subprocess.run(["curl", "-o", os.environ["HOME"].removesuffix("/") + "/.local/bin/jellyfin-rpc", "-L", f"https://github.com/Radiicall/jellyfin-rpc/releases/latest/download/{linux_binary}"])
     subprocess.run(["chmod", "+x", os.environ["HOME"].removesuffix("/") + "/.local/bin/jellyfin-rpc"])
 
     if os.environ.get("XDG_CONFIG_HOME"):

--- a/scripts/installer.py
+++ b/scripts/installer.py
@@ -11,9 +11,12 @@ import platform
 from time import sleep
 import sys
 
+# Covering all the possible arch, aarch variations
+def is_arm32():
+    return True if ('aarch' in platform.machine().lower() or 'arm' in platform.machine().lower()) and ('32' in platform.machine().lower() or 'v7' in platform.machine().lower()) else False
 
-def is_arm():
-    return True if 'arm' in platform.machine().lower() or 'aarch' in platform.machine().lower() else False
+def is_arm64():
+    return True if ('aarch' in platform.machine().lower() or 'arm' in platform.machine().lower()) and ('64' in platform.machine().lower() or 'v8' in platform.machine().lower()) else False
 
 path = ""
 
@@ -393,8 +396,10 @@ elif platform.system() == "Darwin":
         print("If needed, you can run Jellyfin RPC at any time by running 'jellyfin-rpc' in a terminal.")
         break
 else:
-    if is_arm():
-      linux_binary = "jellyfin-rpc-arm-linux"
+    if is_arm32():
+      linux_binary = "jellyfin-rpc-arm32-linux"
+    elif is_arm64():
+      linux_binary = "jellyfin-rpc-arm64-linux"
     else :
       linux_binary = "jellyfin-rpc-x86_64-linux"
 

--- a/scripts/installer.py
+++ b/scripts/installer.py
@@ -12,11 +12,11 @@ from time import sleep
 import sys
 
 # Covering all the possible arch, aarch variations
-def is_arm32():
-    return True if ('aarch' in platform.machine().lower() or 'arm' in platform.machine().lower()) and ('32' in platform.machine().lower() or 'v7' in platform.machine().lower()) else False
-
 def is_arm64():
-    return True if ('aarch' in platform.machine().lower() or 'arm' in platform.machine().lower()) and ('64' in platform.machine().lower() or 'v8' in platform.machine().lower()) else False
+    return True if 'aarch64' in platform.machine().lower() or 'armv8' in platform.machine().lower() else False
+
+def is_arm32():
+    return True if 'aarch' in platform.machine().lower() or 'arm' in platform.machine().lower() else False
 
 path = ""
 
@@ -396,10 +396,10 @@ elif platform.system() == "Darwin":
         print("If needed, you can run Jellyfin RPC at any time by running 'jellyfin-rpc' in a terminal.")
         break
 else:
-    if is_arm32():
-      linux_binary = "jellyfin-rpc-arm32-linux"
-    elif is_arm64():
+    if is_arm64():
       linux_binary = "jellyfin-rpc-arm64-linux"
+    elif is_arm32():
+      linux_binary = "jellyfin-rpc-arm32-linux"
     else :
       linux_binary = "jellyfin-rpc-x86_64-linux"
 


### PR DESCRIPTION
As visible from the title, this pull request adds the following:

- ARM support
I have tried the generated binary on raspberry pi 2b (ARMv7), and im fully hoping AARCH64 has backwards compatibility for 32-bit so we can call it full ARM support on linux xd. Stripping is done by emulating alpine linux to the armv7 arch because when i tried to strip it on a x64 bit system it failed.
- Formatting change
Now i am not quite sure if you will like this change, but i think having it in a format S1 - E1 is better than S1E1, but of course this is purely subjective
- Ommiting episode names
I find it quite clunky when the whole name is there, so i added an option to just have S1 - E1 instead of S1 - E1 Episode name
- Adding a leading 0
Last but not least, i added the option to append 0 to the season or episode number if its less than 9 (hopefully xd) so S01 - E01
If you have any questions please ask! I really like this project and i just dont understand why this hasnt been done natively by jellyfin yet