### PR TITLE
Add Movie Display Options

### DIFF
--- a/example.json
+++ b/example.json
@@ -4,7 +4,11 @@
         "api_key": "sadasodsapasdskd",
         "username": "your_username_here",
         "music": {
-            "display": "genres",
+            "display": ["genres"],
+            "separator": "-"
+        },
+        "movies": {
+            "display": ["genres"],
             "separator": "-"
         },
         "self_signed_cert": false,

--- a/jellyfin-rpc-cli/src/main.rs
+++ b/jellyfin-rpc-cli/src/main.rs
@@ -100,6 +100,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         builder.music_separator(separator);
     }
 
+    if let Some(display) = conf.jellyfin.movies.display {
+        debug!("Found config.jellyfin.music.display");
+        builder.movies_display(display);
+    }
+
+    if let Some(separator) = conf.jellyfin.movies.separator {
+        debug!("Found config.jellyfin.music.separator");
+        builder.movies_separator(separator);
+    }
+
     if let Some(media_types) = conf.jellyfin.blacklist.media_types {
         debug!("Found config.jellyfin.blacklist.media_types");
         builder.blacklist_media_types(media_types);
@@ -139,6 +149,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             },
         }
     }).unwrap();
+    info!("Connected!");
 
     let mut currently_playing = String::new();
 
@@ -168,6 +179,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         },
                     }
                 }).unwrap();
+                info!("Reconnected!");
             
                 client.set_activity()?;
             },

--- a/jellyfin-rpc/src/jellyfin.rs
+++ b/jellyfin-rpc/src/jellyfin.rs
@@ -156,6 +156,8 @@ pub struct NowPlayingItem {
     pub production_year: Option<i64>,
     pub genres: Option<Vec<String>>,
     pub external_urls: Option<Vec<ExternalUrl>>,
+    pub critic_rating: Option<i64>,
+    pub community_rating: Option<f64>,
     // Episode related
     pub parent_index_number: Option<i32>,
     pub index_number: Option<i32>,

--- a/scripts/installer.py
+++ b/scripts/installer.py
@@ -110,6 +110,36 @@ if current == "n" or current == "":
         break
 
     while True:
+        val = input("Do you want to customize movie display? (y/N): ").lower()
+
+        if val == "n" or val == "":
+            movies = None
+            break
+        elif val != "y":
+            print("Invalid input, please type y or n")
+            continue
+
+        print("Enter what you would like to be shown in a comma seperated list")
+        print("Remember that it will show in the order you type it in")
+        print("Valid options are year, critic-score, community-score and/or genres")
+        display = input("[Default: genres]: ").split(",")
+
+        print("Choose the separator between the artist name and the info")
+        separator = input("[Default: -]: ")
+
+        if display == "":
+            display = None
+        if separator == "":
+            separator = None
+
+        movies = {
+            "display": display,
+            "separator": separator
+        }
+
+        break
+
+    while True:
         val = input("Do you want to blacklist media types or libraries? (y/N): ").lower()
 
         if val == "n" or val == "":
@@ -146,7 +176,7 @@ if current == "n" or current == "":
     else:
         show_simple = False
 
-    append_prefix = input("Do you want to add a leading 0 to season and episode numbers? (Y/n): ").lower()
+    append_prefix = input("Do you want to add a leading 0 to season and episode numbers? (y/N): ").lower()
 
     if append_prefix == "y":
         append_prefix = True
@@ -155,7 +185,7 @@ if current == "n" or current == "":
     else:
         append_prefix = False
 
-    add_divider = input("Do you want to add a divider between numbers, ex. S01 - E01? (Y/n): ").lower()
+    add_divider = input("Do you want to add a divider between numbers, ex. S01 - E01? (y/N): ").lower()
 
     if add_divider == "y":
         add_divider = True
@@ -169,6 +199,7 @@ if current == "n" or current == "":
         "api_key": api_key,
         "username": username,
         "music": music,
+        "movies": movies,
         "blacklist": blacklist,
         "self_signed_cert": self_signed_cert,
         "show_simple": show_simple,
@@ -189,7 +220,7 @@ if current == "n" or current == "":
     elif show_paused == "n":
         show_paused = False
     else:
-        show_paused = None
+        show_paused = True
 
     print("----------Buttons----------")
 


### PR DESCRIPTION
Lets you customize how movies are displayed, exactly like how music is!

config example
```json
{
  "jellyfin": {
    "movies": {
      "display": [
        "year",
        "critic-score",
        "community-score",
        "genres"
      ],
      "separator": "|"
    },
    ...
  }
  ...
}
```