### PR TITLE
Use authorization header instead of adding to query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,26 +421,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "jellyfin-rpc"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6efcb23437431e62601716054e2f593f52a8d3d2f41916ec3928f4b763c1409"
-dependencies = [
- "discord-rich-presence",
- "log",
- "reqwest",
- "serde",
- "serde_json",
- "url",
-]
-
-[[package]]
 name = "jellyfin-rpc-cli"
 version = "1.2.1"
 dependencies = [
  "clap",
  "colored",
- "jellyfin-rpc 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jellyfin-rpc",
  "log",
  "reqwest",
  "retry",

--- a/jellyfin-rpc-cli/Cargo.toml
+++ b/jellyfin-rpc-cli/Cargo.toml
@@ -29,8 +29,8 @@ time                  = "0.3"
 serde_json            = "1.0"
 
 [dependencies.jellyfin-rpc]
-version  = "1.2.1"
-#path = "../jellyfin-rpc"
+#version  = "1.2.1"
+path = "../jellyfin-rpc"
 
 [dependencies.clap]
 features = ["derive"]

--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -7,6 +7,7 @@ pub use error::JfError;
 pub use jellyfin::{Button, MediaType};
 use jellyfin::{EndTime, Item, RawSession, Session};
 use log::debug;
+use reqwest::header::AUTHORIZATION;
 use std::str::FromStr;
 use url::{ParseError, Url};
 
@@ -187,7 +188,9 @@ impl Client {
     fn get_session(&mut self) -> Result<(), reqwest::Error> {
         let sessions: Vec<RawSession> = self
             .reqwest
-            .get(format!("{}Sessions?api_key={}", self.url, self.api_key))
+            .get(format!("{}Sessions", self.url))
+            .header(AUTHORIZATION, format!("Token=\"{}\"", self.api_key))
+            .header("X-Emby-Token", &self.api_key)
             .send()?
             .json()?;
 
@@ -493,9 +496,11 @@ impl Client {
         let ancestors: Vec<Item> = self
             .reqwest
             .get(self.url.join(&format!(
-                "Items/{}/Ancestors?api_key={}",
-                session.now_playing_item.id, self.api_key
+                "Items/{}/Ancestors",
+                session.now_playing_item.id
             ))?)
+            .header(AUTHORIZATION, format!("Token=\"{}\"", self.api_key))
+            .header("X-Emby-Token", &self.api_key)
             .send()?
             .json()?;
 

--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -189,7 +189,7 @@ impl Client {
         let sessions: Vec<RawSession> = self
             .reqwest
             .get(format!("{}Sessions", self.url))
-            .header(AUTHORIZATION, format!("Token=\"{}\"", self.api_key))
+            .header(AUTHORIZATION, format!("MediaBrowser Token=\"{}\"", self.api_key))
             .header("X-Emby-Token", &self.api_key)
             .send()?
             .json()?;
@@ -499,7 +499,7 @@ impl Client {
                 "Items/{}/Ancestors",
                 session.now_playing_item.id
             ))?)
-            .header(AUTHORIZATION, format!("Token=\"{}\"", self.api_key))
+            .header(AUTHORIZATION, format!("MediaBrowser Token=\"{}\"", self.api_key))
             .header("X-Emby-Token", &self.api_key)
             .send()?
             .json()?;


### PR DESCRIPTION
This should avoid some logging issues when reporting bugs and also up the general security of the requests