### PR TITLE
Change default wait time

### DIFF
--- a/jellyfin-rpc-cli/src/main.rs
+++ b/jellyfin-rpc-cli/src/main.rs
@@ -33,7 +33,7 @@ struct Args {
         short = 't',
         long = "wait-time",
         help = "Time to wait between loops in seconds",
-        default_value_t = 3
+        default_value_t = 7
     )]
     wait_time: usize,
     #[arg(


### PR DESCRIPTION
Increasing from 3 to 7 to try and fix issues with pipe closing very often.
Fixes #137 