### PR TITLE
Default config file name fixes

### DIFF
--- a/jellyfin-rpc-cli/src/config.rs
+++ b/jellyfin-rpc-cli/src/config.rs
@@ -175,13 +175,13 @@ pub fn get_urls_path() -> Result<String, Box<dyn std::error::Error>> {
     }
 }
 
-/// Find config.json in filesystem.
+/// Find default config path (main.json) in filesystem.
 ///
 /// This is to avoid the user having to specify a filepath on launch.
 ///
 /// Default config path depends on OS
-/// Windows: `%appdata%\jellyfin-rpc\config.json`
-/// Linux/macOS: `~/.config/jellyfin-rpc/config.json`
+/// Windows: `%appdata%\jellyfin-rpc\main.json`
+/// Linux/macOS: `~/.config/jellyfin-rpc/main.json`
 pub fn get_config_path() -> Result<String, Box<dyn std::error::Error>> {
     debug!("Getting config path");
     if cfg!(not(windows)) {

--- a/jellyfin-rpc-cli/src/main.rs
+++ b/jellyfin-rpc-cli/src/main.rs
@@ -73,8 +73,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let conf = match Config::builder().load(conf_path) {
         Ok(file) => file.build(),
-        Err(_error) => {
-            error!("Config file could not be found at path: {}", conf_path.red());
+        Err(error) => {
+            error!("Config file could not be loaded at path: {}", conf_path.red());
+            error!("{}", error);
             error!("Please create a proper config file: {}", "https://github.com/Radiicall/jellyfin-rpc/wiki/Setup".green());
             std::process::exit(1)
         }

--- a/jellyfin-rpc-cli/src/main.rs
+++ b/jellyfin-rpc-cli/src/main.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use colored::Colorize;
 use config::{get_config_path, get_urls_path, Config};
 use jellyfin_rpc::Client;
 use log::{debug, error, info};
@@ -66,14 +67,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(feature = "updates")]
     updates::checker();
 
-    let conf = Config::builder()
-        .load(
-            &args
-                .config
-                .unwrap_or(get_config_path().expect("default config path couldn't be determined")),
-        )
-        .expect("config not found")
-        .build();
+    let conf_path = &args
+        .config
+        .unwrap_or(get_config_path().expect("default config path couldn't be determined"));
+
+    let conf = match Config::builder().load(conf_path) {
+        Ok(file) => file.build(),
+        Err(_error) => {
+            error!("Config file could not be found at path: {}", conf_path.red());
+            error!("Please create a proper config file: {}", "https://github.com/Radiicall/jellyfin-rpc/wiki/Setup".green());
+            std::process::exit(1)
+        }
+    };
 
     debug!("Creating jellyfin-rpc client builder");
     let mut builder = Client::builder();


### PR DESCRIPTION
Fixes #162. This PR fixes an unclear function comment and adds a clean error exit to the failure to find a config file. I believe this is better for a user that hasn't made their config file yet or passing the wrong path parameter compared to just panicking.


Example run with missing main.json
```bash
> .\jellyfin-rpc.exe
2024-10-24 13:58:46 INFO  [jellyfin_rpc] Initializing Jellyfin-RPC
2024-10-24 13:58:47 ERROR [jellyfin_rpc] Config file could not be found at path: C:\Users\tronl\AppData\Roaming\jellyfin-rpc\main.json
2024-10-24 13:58:47 ERROR [jellyfin_rpc] Please create a proper config file: https://github.com/Radiicall/jellyfin-rpc/wiki/Setup
```

Example run with incorrect config parameter
```bash
> .\jellyfin-rpc.exe -c ./config.json
2024-10-24 14:03:21 INFO  [jellyfin_rpc] Initializing Jellyfin-RPC
2024-10-24 14:03:21 ERROR [jellyfin_rpc] Config file could not be found at path: ./config.json
2024-10-24 14:03:21 ERROR [jellyfin_rpc] Please create a proper config file: https://github.com/Radiicall/jellyfin-rpc/wiki/Setup
```