### PR TITLE
Implement custom activity text formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,26 +422,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "jellyfin-rpc"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf58e81834dcd46aa84eb1a8a076de0d99eb98e007bb124891997e28a9fc75f"
-dependencies = [
- "discord-rich-presence",
- "log",
- "reqwest",
- "serde",
- "serde_json",
- "url",
-]
-
-[[package]]
 name = "jellyfin-rpc-cli"
 version = "1.3.0"
 dependencies = [
  "clap",
  "colored",
- "jellyfin-rpc 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jellyfin-rpc",
  "log",
  "reqwest",
  "retry",

--- a/jellyfin-rpc-cli/Cargo.toml
+++ b/jellyfin-rpc-cli/Cargo.toml
@@ -29,8 +29,7 @@ time                  = "0.3"
 serde_json            = "1.0"
 
 [dependencies.jellyfin-rpc]
-version  = "1.3.0"
-#path = "../jellyfin-rpc"
+path = "../jellyfin-rpc"
 
 [dependencies.clap]
 features = ["derive"]

--- a/jellyfin-rpc-cli/src/config.rs
+++ b/jellyfin-rpc-cli/src/config.rs
@@ -1,4 +1,4 @@
-use jellyfin_rpc::{Button, MediaType, DisplayFormat};
+use jellyfin_rpc::{Button, DisplayFormat, MediaType};
 use log::debug;
 use serde::{Deserialize, Serialize};
 use std::env;

--- a/jellyfin-rpc-cli/src/config.rs
+++ b/jellyfin-rpc-cli/src/config.rs
@@ -1,4 +1,4 @@
-use jellyfin_rpc::{Button, MediaType};
+use jellyfin_rpc::{Button, MediaType, DisplayFormat};
 use log::debug;
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -46,7 +46,7 @@ pub struct Jellyfin {
 /// Contains configuration for Music/Movie display.
 pub struct DisplayOptions {
     /// Display is where you tell the program what should be displayed.
-    pub display: Option<Vec<String>>,
+    pub display: Option<DisplayFormat>,
     /// Separator is what should be between the artist(s) and the `display` options.
     pub separator: Option<String>,
 }
@@ -121,6 +121,8 @@ pub enum Display {
     Vec(Vec<String>),
     /// If the Display is a comma separated `String`.
     String(String),
+    /// If the Display is a `DisplayFormat` struct.
+    CustomFormat(DisplayFormat),
 }
 
 /// Blacklist MediaTypes and libraries.
@@ -244,9 +246,10 @@ impl ConfigBuilder {
         if let Some(music) = self.jellyfin.music {
             if let Some(disp) = music.display {
                 music_display = Some(match disp {
-                    Display::Vec(display) => display,
-                    Display::String(display) => display.split(',').map(|d| d.to_string()).collect(),
-                })
+                    Display::Vec(display) => DisplayFormat::from(display),
+                    Display::String(display) => DisplayFormat::from(display),
+                    Display::CustomFormat(display) => display,
+                });
             } else {
                 music_display = None;
             }
@@ -263,9 +266,10 @@ impl ConfigBuilder {
         if let Some(movies) = self.jellyfin.movies {
             if let Some(disp) = movies.display {
                 movie_display = Some(match disp {
-                    Display::Vec(display) => display,
-                    Display::String(display) => display.split(',').map(|d| d.to_string()).collect(),
-                })
+                    Display::Vec(display) => DisplayFormat::from(display),
+                    Display::String(display) => DisplayFormat::from(display),
+                    Display::CustomFormat(display) => display,
+                });
             } else {
                 movie_display = None;
             }

--- a/jellyfin-rpc-cli/src/main.rs
+++ b/jellyfin-rpc-cli/src/main.rs
@@ -72,9 +72,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let conf = match Config::builder().load(conf_path) {
         Ok(file) => file.build(),
         Err(error) => {
-            error!("Config file could not be loaded at path: {}", conf_path.red());
+            error!(
+                "Config file could not be loaded at path: {}",
+                conf_path.red()
+            );
             error!("{}", error);
-            error!("Please create a proper config file: {}", "https://github.com/Radiicall/jellyfin-rpc/wiki/Setup".green());
+            error!(
+                "Please create a proper config file: {}",
+                "https://github.com/Radiicall/jellyfin-rpc/wiki/Setup".green()
+            );
             std::process::exit(1)
         }
     };

--- a/jellyfin-rpc-cli/src/main.rs
+++ b/jellyfin-rpc-cli/src/main.rs
@@ -93,6 +93,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .show_paused(conf.discord.show_paused)
         .show_images(conf.images.enable_images)
         .use_imgur(conf.images.imgur_images)
+        .large_image_text(format!("Jellyfin-RPC v{}", VERSION.unwrap_or("UNKNOWN")))
         .imgur_urls_file_location(args.image_urls.unwrap_or(get_urls_path()?));
 
     if let Some(display) = conf.jellyfin.music.display {

--- a/jellyfin-rpc-cli/src/main.rs
+++ b/jellyfin-rpc-cli/src/main.rs
@@ -95,7 +95,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .show_paused(conf.discord.show_paused)
         .show_images(conf.images.enable_images)
         .use_imgur(conf.images.imgur_images)
-        .large_image_text(format!("Jellyfin-RPC v{}", VERSION.unwrap_or("UNKNOWN")))
         .imgur_urls_file_location(args.image_urls.unwrap_or(get_urls_path()?));
 
     if let Some(display) = conf.jellyfin.music.display {

--- a/jellyfin-rpc-cli/src/main.rs
+++ b/jellyfin-rpc-cli/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use colored::Colorize;
 use config::{get_config_path, get_urls_path, Config};
-use jellyfin_rpc::Client;
+use jellyfin_rpc::{Client, VERSION};
 use log::{debug, error, info};
 use retry::retry_with_index;
 use simple_logger::SimpleLogger;
@@ -14,8 +14,6 @@ mod updates;
 /*
     TODO: Comments
 */
-
-const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
 
 #[derive(Parser)]
 #[command(author = "Radical <Radiicall> <radical@radical.fun>")]

--- a/jellyfin-rpc/src/jellyfin.rs
+++ b/jellyfin-rpc/src/jellyfin.rs
@@ -36,22 +36,6 @@ pub struct Session {
 }
 
 impl Session {
-    pub fn get_details(&self) -> &str {
-        match self.now_playing_item.media_type {
-            MediaType::Episode => self
-                .now_playing_item
-                .series_name
-                .as_ref()
-                .unwrap_or(&self.now_playing_item.name),
-            MediaType::AudioBook => self
-                .now_playing_item
-                .album
-                .as_ref()
-                .unwrap_or(&self.now_playing_item.name),
-            _ => &self.now_playing_item.name,
-        }
-    }
-
     /// Formats artists with comma separation and a final "and" before the last name.
     pub fn format_artists(&self) -> String {
         // let default is to create a longer lived value for artists_vec

--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -343,80 +343,88 @@ impl Client {
         }
     }
 
+    fn parse_music_display(&self, input: &str) -> String {
+        let session = self.session.as_ref().unwrap();
+
+        let separator = &self.music_display_options.separator;
+        let track = session.now_playing_item.name.as_ref();
+        let artists = session.format_artists();
+        let genres = session
+            .now_playing_item
+            .genres
+            .as_ref()
+            .unwrap_or(&vec!["Unknown genre".to_string()])
+            .join(", ");
+        let year = session
+            .now_playing_item
+            .production_year
+            .map(|y| y.to_string())
+            .unwrap_or("Unknown year".to_string());
+        let album = session
+            .now_playing_item
+            .album
+            .as_ref()
+            .unwrap_or(&"Unknown album".to_string())
+            .clone();
+
+        input
+            .replace("{track}", &track)
+            .replace("{album}", &album)
+            .replace("{artists}", &artists)
+            .replace("{genres}", &genres)
+            .replace("{year}", &year)
+            .replace("{sep}", &separator)
+            .replace("{version}", VERSION.unwrap_or("UNKNOWN"))
+    }
+
+    fn parse_movies_display(&self, input: &str) -> String {
+        let session = self.session.as_ref().unwrap();
+
+        let separator = &self.movies_display_options.separator;
+        let title = session.now_playing_item.name.as_ref();
+        let genres = session
+            .now_playing_item
+            .genres
+            .as_ref()
+            .unwrap_or(&vec!["Unknown genre".to_string()])
+            .join(", ");
+        let year = session
+            .now_playing_item
+            .production_year
+            .map(|y| y.to_string())
+            .unwrap_or("Unknown year".to_string());
+        let critic_score = &session
+            .now_playing_item
+            .critic_rating
+            .map(|s| format!("🍅{}/100", s))
+            .unwrap_or("🍅 ?/100".to_string());
+        let community_score = &session
+            .now_playing_item
+            .community_rating
+            .map(|s| format!("⭐{:.1}/10", s))
+            .unwrap_or("⭐ ?/10".to_string());
+
+        input
+            .replace("{title}", &title)
+            .replace("{genres}", &genres)
+            .replace("{year}", &year)
+            .replace("{critic-score}", &critic_score)
+            .replace("{community-score}", &community_score)
+            .replace("{sep}", &separator)
+            .replace("{version}", VERSION.unwrap_or("UNKNOWN"))
+    }
+
     fn get_details(&self) -> String {
         let session = self.session.as_ref().unwrap();
 
         match session.now_playing_item.media_type {
             MediaType::Music => {
                 let display_details_format = &self.music_display_options.display.details_text.as_ref().unwrap();
-
-                let separator = &self.music_display_options.separator;
-                let track = session.now_playing_item.name.as_ref();
-                let artists = session.format_artists();
-                let genres = session
-                    .now_playing_item
-                    .genres
-                    .as_ref()
-                    .unwrap_or(&vec!["Unknown genre".to_string()])
-                    .join(", ");
-                let year = session
-                    .now_playing_item
-                    .production_year
-                    .map(|y| y.to_string())
-                    .unwrap_or("Unknown year".to_string());
-                let album = session
-                    .now_playing_item
-                    .album
-                    .as_ref()
-                    .unwrap_or(&"Unknown album".to_string())
-                    .clone();
-
-                display_details_format
-                    .replace("{__default}", "{track}")
-                    .replace("{track}", &track)
-                    .replace("{album}", &album)
-                    .replace("{artists}", &artists)
-                    .replace("{genres}", &genres)
-                    .replace("{year}", &year)
-                    .replace("{sep}", &separator)
-                    .replace("{version}", VERSION.unwrap_or("UNKNOWN"))
+                self.parse_music_display(display_details_format.replace("{__default}", "{track}").as_str())
             }
             MediaType::Movie => {
                 let display_details_format = &self.movies_display_options.display.details_text.as_ref().unwrap();
-
-                let separator = &self.movies_display_options.separator;
-                let title = session.now_playing_item.name.as_ref();
-                let genres = session
-                    .now_playing_item
-                    .genres
-                    .as_ref()
-                    .unwrap_or(&vec!["Unknown genre".to_string()])
-                    .join(", ");
-                let year = session
-                    .now_playing_item
-                    .production_year
-                    .map(|y| y.to_string())
-                    .unwrap_or("Unknown year".to_string());
-                let critic_score = &session
-                    .now_playing_item
-                    .critic_rating
-                    .map(|s| format!("🍅{}/100", s))
-                    .unwrap_or("🍅 ?/100".to_string());
-                let community_score = &session
-                    .now_playing_item
-                    .community_rating
-                    .map(|s| format!("⭐{:.1}/10", s))
-                    .unwrap_or("⭐ ?/10".to_string());
-
-                display_details_format
-                    .replace("{__default}", "{title}")
-                    .replace("{title}", &title)
-                    .replace("{genres}", &genres)
-                    .replace("{year}", &year)
-                    .replace("{critic-score}", &critic_score)
-                    .replace("{community-score}", &community_score)
-                    .replace("{sep}", &separator)
-                    .replace("{version}", VERSION.unwrap_or("UNKNOWN"))
+                self.parse_movies_display(&display_details_format.replace("{__default}", "{title}").as_str())
             }
             MediaType::Episode => {
                 session
@@ -485,37 +493,7 @@ impl Client {
             MediaType::LiveTv => "Live TV".to_string(),
             MediaType::Music => {
                 let display_state_format = &self.music_display_options.display.state_text.as_ref().unwrap();
-
-                let separator = &self.music_display_options.separator;
-                let track = session.now_playing_item.name.as_ref();
-                let artists = session.format_artists();
-                let genres = session
-                    .now_playing_item
-                    .genres
-                    .as_ref()
-                    .unwrap_or(&vec!["Unknown genre".to_string()])
-                    .join(", ");
-                let year = session
-                    .now_playing_item
-                    .production_year
-                    .map(|y| y.to_string())
-                    .unwrap_or("Unknown year".to_string());
-                let album = session
-                    .now_playing_item
-                    .album
-                    .as_ref()
-                    .unwrap_or(&"Unknown album".to_string())
-                    .clone();
-
-                display_state_format
-                    .replace("{__default}", "By {artists} {sep} ")
-                    .replace("{track}", &track)
-                    .replace("{album}", &album)
-                    .replace("{artists}", &artists)
-                    .replace("{genres}", &genres)
-                    .replace("{year}", &year)
-                    .replace("{sep}", &separator)
-                    .replace("{version}", VERSION.unwrap_or("UNKNOWN"))
+                self.parse_music_display(display_state_format.replace("{__default}", "By {artists} {sep}").as_str())
             }
             MediaType::Book => {
                 let mut state = String::new();
@@ -556,40 +534,7 @@ impl Client {
             }
             MediaType::Movie => {
                 let display_state_format = &self.movies_display_options.display.state_text.as_ref().unwrap();
-
-                let separator = &self.movies_display_options.separator;
-                let title = session.now_playing_item.name.as_ref();
-                let genres = session
-                    .now_playing_item
-                    .genres
-                    .as_ref()
-                    .unwrap_or(&vec!["Unknown genre".to_string()])
-                    .join(", ");
-                let year = session
-                    .now_playing_item
-                    .production_year
-                    .map(|y| y.to_string())
-                    .unwrap_or("Unknown year".to_string());
-                let critic_score = &session
-                    .now_playing_item
-                    .critic_rating
-                    .map(|s| format!("🍅{}/100", s))
-                    .unwrap_or("🍅 ?/100".to_string());
-                let community_score = &session
-                    .now_playing_item
-                    .community_rating
-                    .map(|s| format!("⭐{:.1}/10", s))
-                    .unwrap_or("⭐ ?/10".to_string());
-
-                display_state_format
-                    .replace("{__default}", "")
-                    .replace("{title}", &title)
-                    .replace("{genres}", &genres)
-                    .replace("{year}", &year)
-                    .replace("{critic-score}", &critic_score)
-                    .replace("{community-score}", &community_score)
-                    .replace("{sep}", &separator)
-                    .replace("{version}", VERSION.unwrap_or("UNKNOWN"))
+                self.parse_movies_display(&display_state_format.replace("{__default}", "").as_str())
             }
             _ => session
                 .now_playing_item
@@ -606,72 +551,11 @@ impl Client {
         match session.now_playing_item.media_type {
             MediaType::Music => {
                 let display_image_format = &self.music_display_options.display.image_text.as_ref().unwrap();
-
-                let separator = &self.music_display_options.separator;
-                let track = session.now_playing_item.name.as_ref();
-                let artists = session.format_artists();
-                let genres = session
-                    .now_playing_item
-                    .genres
-                    .as_ref()
-                    .unwrap_or(&vec!["Unknown genre".to_string()])
-                    .join(", ");
-                let year = session
-                    .now_playing_item
-                    .production_year
-                    .map(|y| y.to_string())
-                    .unwrap_or("Unknown year".to_string());
-                let album = session
-                    .now_playing_item
-                    .album
-                    .as_ref()
-                    .unwrap_or(&"Unknown album".to_string())
-                    .clone();
-
-                display_image_format
-                    .replace("{track}", &track)
-                    .replace("{album}", &album)
-                    .replace("{artists}", &artists)
-                    .replace("{genres}", &genres)
-                    .replace("{year}", &year)
-                    .replace("{sep}", &separator)
-                    .replace("{version}", VERSION.unwrap_or("UNKNOWN"))
+                self.parse_music_display(&display_image_format)
             }
             MediaType::Movie => {
                 let display_image_format = &self.movies_display_options.display.image_text.as_ref().unwrap();
-
-                let separator = &self.movies_display_options.separator;
-                let title = session.now_playing_item.name.as_ref();
-                let genres = session
-                    .now_playing_item
-                    .genres
-                    .as_ref()
-                    .unwrap_or(&vec!["".to_string()])
-                    .join(", ");
-                let year = session
-                    .now_playing_item
-                    .production_year
-                    .map(|y| y.to_string())
-                    .unwrap_or("Unknown year".to_string());
-                let critic_score = &session
-                    .now_playing_item
-                    .critic_rating
-                    .map(|s| format!("🍅{}/100", s))
-                    .unwrap_or("🍅 ?/100".to_string());
-                let community_score = &session
-                    .now_playing_item
-                    .community_rating
-                    .map(|s| format!("⭐{:.1}/10", s))
-                    .unwrap_or("⭐ ?/10".to_string());
-
-                display_image_format
-                    .replace("{title}", &title)
-                    .replace("{genres}", &genres)
-                    .replace("{year}", &year)
-                    .replace("{critic-score}", &critic_score)
-                    .replace("{community-score}", &community_score)
-                    .replace("{sep}", &separator)
-                    .replace("{version}", VERSION.unwrap_or("UNKNOWN"))
+                self.parse_movies_display(&display_image_format)
             }
             _ => "".to_string(),
         }

--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -638,7 +638,7 @@ impl From<Vec<String>> for DisplayFormat {
 
         let items_joined = items
             .iter()
-            .map(|i| format!("{{{}}}", i))
+            .map(|i| format!("{{{}}}", i.trim()))
             .collect::<Vec<String>>()
             .join(" {sep} ");
 

--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -348,20 +348,12 @@ impl Client {
     }
 
     fn sanitize_display_format(input: &str) -> String {
-        let mut result = input.to_string();
-
-        result = result.trim().to_string();
-
         // Remove unnecessary spaces
-        while result.contains("  ") {
-            result = result.replace("  ", " ");
-        }
+        let mut result = input.trim().split_whitespace().collect::<Vec<&str>>().join(" ");
 
         // Remove duplicated separators
-        while result.contains("{sep}{sep}") {
+        while result.contains("{sep}{sep}") || result.contains("{sep} {sep}") {
             result = result.replace("{sep}{sep}", "{sep}");
-        }
-        while result.contains("{sep} {sep}") {
             result = result.replace("{sep} {sep}", "{sep}");
         }
 

--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -396,12 +396,12 @@ impl Client {
         let critic_score = &session
             .now_playing_item
             .critic_rating
-            .map(|s| format!("🍅{}/100", s))
+            .map(|s| format!("🍅 {}/100", s))
             .unwrap_or("🍅 ?/100".to_string());
         let community_score = &session
             .now_playing_item
             .community_rating
-            .map(|s| format!("⭐{:.1}/10", s))
+            .map(|s| format!("⭐ {:.1}/10", s))
             .unwrap_or("⭐ ?/10".to_string());
 
         input

--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -165,7 +165,7 @@ impl Client {
             if state.len() > 128 {
                 state = state.chars().take(128).collect();
             } else if state.len() < 3 {
-                // Add three zero width joiners due to discord requiring a minimum length of 3 chars in statuses 
+                // Add three zero width joiners due to discord requiring a minimum length of 3 chars in statuses
                 state += "‎‎‎";
             }
 
@@ -213,7 +213,6 @@ impl Client {
         }
         Ok(String::new())
     }
-
 
     fn get_session(&mut self) -> Result<(), reqwest::Error> {
         let sessions: Vec<RawSession> = self
@@ -353,7 +352,7 @@ impl Client {
 
     fn sanitize_display_format(input: &str) -> String {
         // Remove unnecessary spaces
-        let mut result = input.trim().split_whitespace().collect::<Vec<&str>>().join(" ");
+        let mut result = input.split_whitespace().collect::<Vec<&str>>().join(" ");
 
         // Remove duplicated separators
         while result.contains("{sep}{sep}") || result.contains("{sep} {sep}") {
@@ -363,10 +362,19 @@ impl Client {
 
         // Remove unnecessary separators
         while result.starts_with("{sep}") {
-            result = result.drain(5..).collect::<String>().trim_start().to_string();
+            result = result
+                .drain(5..)
+                .collect::<String>()
+                .trim_start()
+                .to_string();
         }
+
         while result.ends_with("{sep}") {
-            result = result.drain(..result.len() - 5).collect::<String>().trim_end().to_string();
+            result = result
+                .drain(..result.len() - 5)
+                .collect::<String>()
+                .trim_end()
+                .to_string();
         }
 
         result
@@ -398,15 +406,14 @@ impl Client {
             .clone();
 
         result = result
-            .replace("{track}", &track)
+            .replace("{track}", track)
             .replace("{album}", &album)
             .replace("{artists}", &artists)
             .replace("{genres}", &genres)
             .replace("{year}", &year)
             .replace("{version}", VERSION.unwrap_or("UNKNOWN"));
 
-        Self::sanitize_display_format(&result)
-            .replace("{sep}", &separator)
+        Self::sanitize_display_format(&result).replace("{sep}", separator)
     }
 
     fn parse_movies_display(&self, input: &str) -> String {
@@ -438,15 +445,14 @@ impl Client {
             .unwrap_or_default();
 
         result = result
-            .replace("{title}", &title)
+            .replace("{title}", title)
             .replace("{genres}", &genres)
             .replace("{year}", &year)
-            .replace("{critic-score}", &critic_score)
-            .replace("{community-score}", &community_score)
+            .replace("{critic-score}", critic_score)
+            .replace("{community-score}", community_score)
             .replace("{version}", VERSION.unwrap_or("UNKNOWN"));
 
-        Self::sanitize_display_format(&result)
-            .replace("{sep}", &separator)
+        Self::sanitize_display_format(&result).replace("{sep}", separator)
     }
 
     fn get_details(&self) -> String {
@@ -454,29 +460,43 @@ impl Client {
 
         match session.now_playing_item.media_type {
             MediaType::Music => {
-                let display_details_format = &self.music_display_options.display.details_text.as_ref().unwrap();
-                self.parse_music_display(display_details_format.replace("{__default}", "{track}").as_str())
+                let display_details_format = &self
+                    .music_display_options
+                    .display
+                    .details_text
+                    .as_ref()
+                    .unwrap();
+                self.parse_music_display(
+                    display_details_format
+                        .replace("{__default}", "{track}")
+                        .as_str(),
+                )
             }
             MediaType::Movie => {
-                let display_details_format = &self.movies_display_options.display.details_text.as_ref().unwrap();
-                self.parse_movies_display(&display_details_format.replace("{__default}", "{title}").as_str())
-            }
-            MediaType::Episode => {
-                session
-                    .now_playing_item
-                    .series_name
+                let display_details_format = &self
+                    .movies_display_options
+                    .display
+                    .details_text
                     .as_ref()
-                    .map(|s| s.to_string())
-                    .unwrap_or_else(|| session.now_playing_item.name.to_string())
+                    .unwrap();
+                self.parse_movies_display(
+                    display_details_format
+                        .replace("{__default}", "{title}")
+                        .as_str(),
+                )
             }
-            MediaType::AudioBook => {
-                session
-                    .now_playing_item
-                    .album
-                    .as_ref()
-                    .map(|a| a.to_string())
-                    .unwrap_or_else(|| session.now_playing_item.name.to_string())
-            }
+            MediaType::Episode => session
+                .now_playing_item
+                .series_name
+                .as_ref()
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| session.now_playing_item.name.to_string()),
+            MediaType::AudioBook => session
+                .now_playing_item
+                .album
+                .as_ref()
+                .map(|a| a.to_string())
+                .unwrap_or_else(|| session.now_playing_item.name.to_string()),
             _ => session.now_playing_item.name.to_string(),
         }
     }
@@ -527,8 +547,17 @@ impl Client {
             }
             MediaType::LiveTv => "Live TV".to_string(),
             MediaType::Music => {
-                let display_state_format = &self.music_display_options.display.state_text.as_ref().unwrap();
-                self.parse_music_display(display_state_format.replace("{__default}", "By {artists} {sep} ").as_str())
+                let display_state_format = &self
+                    .music_display_options
+                    .display
+                    .state_text
+                    .as_ref()
+                    .unwrap();
+                self.parse_music_display(
+                    display_state_format
+                        .replace("{__default}", "By {artists} {sep} ")
+                        .as_str(),
+                )
             }
             MediaType::Book => {
                 let mut state = String::new();
@@ -568,8 +597,13 @@ impl Client {
                 state
             }
             MediaType::Movie => {
-                let display_state_format = &self.movies_display_options.display.state_text.as_ref().unwrap();
-                self.parse_movies_display(&display_state_format.replace("{__default}", "").as_str())
+                let display_state_format = &self
+                    .movies_display_options
+                    .display
+                    .state_text
+                    .as_ref()
+                    .unwrap();
+                self.parse_movies_display(display_state_format.replace("{__default}", "").as_str())
             }
             _ => session
                 .now_playing_item
@@ -585,12 +619,22 @@ impl Client {
 
         match session.now_playing_item.media_type {
             MediaType::Music => {
-                let display_image_format = &self.music_display_options.display.image_text.as_ref().unwrap();
-                self.parse_music_display(&display_image_format)
+                let display_image_format = &self
+                    .music_display_options
+                    .display
+                    .image_text
+                    .as_ref()
+                    .unwrap();
+                self.parse_music_display(display_image_format)
             }
             MediaType::Movie => {
-                let display_image_format = &self.movies_display_options.display.image_text.as_ref().unwrap();
-                self.parse_movies_display(&display_image_format)
+                let display_image_format = &self
+                    .movies_display_options
+                    .display
+                    .image_text
+                    .as_ref()
+                    .unwrap();
+                self.parse_movies_display(display_image_format)
             }
             _ => "".to_string(),
         }

--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -493,7 +493,7 @@ impl Client {
             MediaType::LiveTv => "Live TV".to_string(),
             MediaType::Music => {
                 let display_state_format = &self.music_display_options.display.state_text.as_ref().unwrap();
-                self.parse_music_display(display_state_format.replace("{__default}", "By {artists} {sep}").as_str())
+                self.parse_music_display(display_state_format.replace("{__default}", "By {artists} {sep} ").as_str())
             }
             MediaType::Book => {
                 let mut state = String::new();

--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -20,7 +20,7 @@ mod tests;
 
 pub(crate) type JfResult<T> = Result<T, Box<dyn std::error::Error>>;
 
-const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
+pub const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
 
 /// Client used to interact with jellyfin and discord
 pub struct Client {

--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -359,12 +359,10 @@ impl Client {
 
         // Remove unnecessary separators
         while result.starts_with("{sep}") {
-            result = result.drain(5..).collect();
-            result = result.trim_start().to_string();
+            result = result.drain(5..).collect::<String>().trim_start().to_string();
         }
         while result.ends_with("{sep}") {
-            result = result.drain(..result.len() - 5).collect();
-            result = result.trim_end().to_string();
+            result = result.drain(..result.len() - 5).collect::<String>().trim_end().to_string();
         }
 
         result

--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -417,7 +417,7 @@ impl Client {
             .now_playing_item
             .genres
             .as_ref()
-            .unwrap_or(&vec!["Unknown genre".to_string()])
+            .unwrap_or(&vec!["".to_string()])
             .join(", ");
         let year = session
             .now_playing_item

--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -178,6 +178,10 @@ impl Client {
 
             let mut image_text = self.get_image_text();
 
+            if image_text.is_empty() {
+                image_text = format!("Jellyfin-RPC v{}", VERSION.unwrap_or("UNKNOWN"));
+            }
+
             if image_text.len() > 128 {
                 image_text = image_text.chars().take(128).collect();
             } else if image_text.len() < 3 {

--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -165,6 +165,7 @@ impl Client {
             if state.len() > 128 {
                 state = state.chars().take(128).collect();
             } else if state.len() < 3 {
+                // Add three zero width joiners due to discord requiring a minimum length of 3 chars in statuses 
                 state += "‎‎‎";
             }
 
@@ -173,6 +174,7 @@ impl Client {
             if details.len() > 128 {
                 details = details.chars().take(128).collect();
             } else if details.len() < 3 {
+                // add three (3) zero width joiners
                 details += "‎‎‎";
             }
 
@@ -185,6 +187,7 @@ impl Client {
             if image_text.len() > 128 {
                 image_text = image_text.chars().take(128).collect();
             } else if image_text.len() < 3 {
+                // add three zero width joiners
                 image_text += "‎‎‎";
             }
 
@@ -210,6 +213,7 @@ impl Client {
         }
         Ok(String::new())
     }
+
 
     fn get_session(&mut self) -> Result<(), reqwest::Error> {
         let sessions: Vec<RawSession> = self

--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -348,7 +348,9 @@ impl Client {
     }
 
     fn sanitize_display_format(input: &str) -> String {
-        let mut result = input.trim().to_string();
+        let mut result = input.to_string();
+
+        result = result.trim().to_string();
 
         // Remove unnecessary spaces
         while result.contains("  ") {
@@ -364,17 +366,13 @@ impl Client {
         }
 
         // Remove unnecessary separators
-        while result.starts_with(" {sep}") {
-            result = result.drain(6..).collect();
-        }
         while result.starts_with("{sep}") {
             result = result.drain(5..).collect();
-        }
-        while result.ends_with(" {sep}") {
-            result = result.drain(..result.len() - 6).collect();
+            result = result.trim_start().to_string();
         }
         while result.ends_with("{sep}") {
             result = result.drain(..result.len() - 5).collect();
+            result = result.trim_end().to_string();
         }
 
         result


### PR DESCRIPTION
Solves #154 

## Changes
- Add support for new `display` format for `music` and `movies`:
  ```jsonc
  // [...]
  "music": {
    "display": {
      "details_text": "{track}",
      "state_text": "{artists} {sep} {genres}",
      "image_text": "{album} ({year})"
    },
    "separator": "•"	    
  },
  "movies": {
    "display": {
      "details_text": "{title} ({year})",
      "state_text": "{genres} {sep} {critic-score} {sep} {community-score}",
      "image_text": "{title} ({year})"
    },
    "separator": "•"
  },
  // [...]
  ```
  Music:
  ![image](https://github.com/user-attachments/assets/2743e33e-cf96-4258-ac0a-c3108bb71834)
  Movie:
  ![image](https://github.com/user-attachments/assets/76ad6c94-ff24-4754-85ec-ef658631a62e)

  Just for fun, another example config, with emojis:
  ```jsonc
  // [...]
  "music": {
    "display": {
      "details_text": "🎧 {track}",
      "state_text": "👤 {artists} 🎭 {genres}",
      "image_text": "💿 {album} ({year})"
    },
    "separator": "•"	    
  },
  "movies": {
    "display": {
      "details_text": "🎬 {title} ({year})",
      "state_text": "🎭 {genres} {critic-score} {community-score}",
      "image_text": "🎬 {title} ({year})"
    },
    "separator": "•"
  },
  // [...]
  ```

  Music:
  ![image](https://github.com/user-attachments/assets/2104e9dd-7aaa-4ad4-965f-eb3f51854181)

  Movies:
  ![image](https://github.com/user-attachments/assets/f29f1954-d202-412c-83ef-2eba0ec1b2f2)

- tested with old configuration:
  ```jsonc
  "music": {
    "display": ["album", "year", "genres"],
    "separator": "::"
  },
  "movies": {
    "display": "year, genres, critic-score, community-score",
    "separator": "-"
  },
  ```
  ![image](https://github.com/user-attachments/assets/2776026a-3189-4c70-b9b2-e882e95eef5a)
  ![image](https://github.com/user-attachments/assets/e320b6b4-9d22-4a4b-b2fd-77715b98e434)


- briefly tested TV Episodes and they seem to work as they did before, **haven't tested AudioBooks, Books or Live TV**
  ![image](https://github.com/user-attachments/assets/a4bca5ca-73d1-4e1a-8305-46473cfb90b6)
- API change: new struct `DisplayFormat`
  - replaces `Vec<String>` as `display` type in `DisplayOptions`
  - options of type `String` or `Vec<String>` get converted to `DisplayOptions` for legacy configuration support 
- supported formatting items:
  - music:
    - `{track}` - track title
    - `{album}` - album title
    - `{artists}` - album artists, comma-separated
    - `{genres}` - genres, comma-separated
    - `{year}` - album release year
    - `{version}` - Jellyfin-RPC version, used for default `image_text`
    - `{sep}` - separator
  - movies:
    - `{title}` - movie title
    - `{genres}` - genres, comma-separated
    - `{year}` - movie release year
    - `{critic-score}` - RT critic score
    - `{community-score}` - RT community score
    - `{version}` - Jellyfin-RPC version, used for default `image_text`
    - `{sep}` - separator
- display format texts are sanitized
  - unnecessary whitespaces are removed (e.g. whitespaces in the beginning, end and multiple space characters in a row)
  - duplicated or "dangling" separators are removed - this should take care of situations when some field is empty and separators can be placed one after another
     
    Example:
    - config: `"state_text": "{genres} {sep} {critic-score} {sep} {community-score}"`
    - currently played movie has no critic score
    - instead of `{genres} {sep}  {sep} {community-score}` it should return `{genres} {sep} {community-score}`