### PR TITLE
Fix Github building MacOS x86_64 as arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,7 +211,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --workspace --locked --release
+          args: --target x86_64-apple-darwin --workspace --locked --release
 
       - name: Rename binary
         run: mv target/release/jellyfin-rpc target/release/jellyfin-rpc-x86_64-darwin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,7 +214,7 @@ jobs:
           args: --target x86_64-apple-darwin --workspace --locked --release
 
       - name: Rename binary
-        run: mv target/release/jellyfin-rpc target/release/jellyfin-rpc-x86_64-darwin
+        run: mv target/x86_64-apple-darwin/release/jellyfin-rpc target/x86_64-apple-darwin/release/jellyfin-rpc-x86_64-darwin
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
@@ -226,7 +226,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: macos-x86_64
-          path: target/release/jellyfin-rpc-x86_64-darwin
+          path: target/x86_64-apple-darwin/release/jellyfin-rpc-x86_64-darwin
 
   macos-arm64:
     runs-on: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --workspace --locked --release
+          args: --target x86_64-apple-darwin --workspace --locked --release
 
       - name: Rename binary
         run: mv target/release/jellyfin-rpc target/release/jellyfin-rpc-x86_64-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,7 @@ jobs:
           args: --target x86_64-apple-darwin --workspace --locked --release
 
       - name: Rename binary
-        run: mv target/release/jellyfin-rpc target/release/jellyfin-rpc-x86_64-darwin
+        run: mv target/x86_64-apple-darwin/release/jellyfin-rpc target/x86_64-apple-darwin/release/jellyfin-rpc-x86_64-darwin
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
@@ -236,7 +236,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            target/release/jellyfin-rpc-x86_64-darwin
+            target/x86_64-apple-darwin/release/jellyfin-rpc-x86_64-darwin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Fixes https://github.com/Radiicall/jellyfin-rpc/issues/180

Github Actions would build the x86_64 release as ARM64