### PR TITLE
Fix timeout error when installing gcc for ubuntu arm 32/64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,8 +67,10 @@ jobs:
           default: true
           override: true
   
-      - name: Install ARM32 gcc
-        run: sudo apt install gcc-arm-linux-gnueabihf -y
+      - name: Update apt and install ARM32 gcc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-linux-gnueabihf
   
       - name: Cache target folder
         uses: actions/cache@v3
@@ -110,9 +112,11 @@ jobs:
           target: aarch64-unknown-linux-gnu
           default: true
           override: true
-  
-      - name: Install ARM64 gcc
-        run: sudo apt install gcc-aarch64-linux-gnu -y
+      
+      - name: Update apt and install ARM64 gcc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
   
       - name: Cache target folder
         uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,11 @@ jobs:
           default: true
           override: true
   
-      - name: Install ARM32 gcc
-        run: sudo apt install gcc-arm-linux-gnueabihf -y
-  
+      - name: Update apt and install ARM32 gcc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-linux-gnueabihf
+    
       - name: Cache target folder
         uses: actions/cache@v3
         env:
@@ -115,9 +117,11 @@ jobs:
           default: true
           override: true
   
-      - name: Install ARM64 gcc
-        run: sudo apt install gcc-aarch64-linux-gnu -y
-  
+      - name: Update apt and install ARM64 gcc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+    
       - name: Cache target folder
         uses: actions/cache@v3
         env:


### PR DESCRIPTION
It seems updating apt while installing gcc is required, as when running test builds on my fork I get this in the build action

```E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/b/binutils/binutils-arm-linux-gnueabihf_2.42-4ubuntu2.3_amd64.deb  404  Not Found [IP: 52.252.163.49 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.```


