### PR TITLE
Update api_key url

### DIFF
--- a/scripts/installer.py
+++ b/scripts/installer.py
@@ -67,7 +67,7 @@ if os.path.isfile(config_path):
 if not use_existing:
     print("----------Jellyfin----------")
     url = input("URL (include http/https): ")
-    api_key = input(f"API key [Create one here: {url}/web/index.html#!/apikeys.html]: ")
+    api_key = input(f"API key [Create one here: {url}/web/#/dashboard/keys]: ")
     print(
         "Enter a single username or enter multiple usernames in a comma separated list."
     )


### PR DESCRIPTION
Update the URL to request an API key from the Jellyfin server.

The old path:
```
/web/index.html#!/apikeys.html
```
…is deprecated or no longer working in modern Jellyfin versions. It results in the page going into a loop.
![loop](https://github.com/user-attachments/assets/9c121fa0-7acf-4296-aed3-813767ecb709)

This replaces it with the correct and currently working path, so the user can actually open the working API Keys Page:
```
/web/#/dashboard/keys
```
![working-api_key-page](https://github.com/user-attachments/assets/e772d689-8853-4a59-90cd-451023cc8fee)


