### PR TITLE
Add support for litterbox.catbox.moe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +135,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +203,12 @@ dependencies = [
  "lazy_static",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "deranged"
@@ -382,6 +417,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +466,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 name = "jellyfin-rpc"
 version = "1.3.3"
 dependencies = [
+ "chrono",
  "discord-rich-presence",
  "log",
  "reqwest",
@@ -433,10 +493,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.65"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -505,6 +566,15 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_threads"
@@ -740,6 +810,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -1077,23 +1153,24 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.88"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.88"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1114,9 +1191,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.88"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1124,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.88"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1137,9 +1214,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.88"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
@@ -1158,6 +1238,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,26 +416,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "jellyfin-rpc"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d46f61e60b67a66d9523a74291864544932d4323a1555f4cd51f178cd3dc4ae"
-dependencies = [
- "discord-rich-presence",
- "log",
- "reqwest",
- "serde",
- "serde_json",
- "url",
-]
-
-[[package]]
 name = "jellyfin-rpc-cli"
 version = "1.3.3"
 dependencies = [
  "clap",
  "colored",
- "jellyfin-rpc 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jellyfin-rpc",
  "log",
  "reqwest",
  "retry",
@@ -483,6 +469,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -653,6 +649,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -1003,6 +1000,12 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-bidi"

--- a/example.json
+++ b/example.json
@@ -40,6 +40,7 @@
     },
     "images": {
         "enable_images": true,
-        "imgur_images": true
+        "imgur_images": true,
+        "litterbox_images": false
     }
 }

--- a/jellyfin-rpc-cli/Cargo.toml
+++ b/jellyfin-rpc-cli/Cargo.toml
@@ -29,8 +29,8 @@ time                  = "0.3"
 serde_json            = "1.0"
 
 [dependencies.jellyfin-rpc]
-#path = "../jellyfin-rpc"
-version = "1.3.3"
+path = "../jellyfin-rpc"
+#version = "1.3.3"
 
 [dependencies.clap]
 features = ["derive"]

--- a/jellyfin-rpc-cli/src/config.rs
+++ b/jellyfin-rpc-cli/src/config.rs
@@ -70,6 +70,8 @@ pub struct Images {
     pub enable_images: bool,
     /// Enables imgur images.
     pub imgur_images: bool,
+    /// Enables litterbox images.
+    pub litterbox_images: bool,
 }
 
 impl Config {
@@ -155,6 +157,7 @@ pub struct Imgur {
 pub struct ImagesBuilder {
     pub enable_images: Option<bool>,
     pub imgur_images: Option<bool>,
+    pub litterbox_images: Option<bool>,
 }
 
 /// Find urls.json in filesystem, used to store images that were already previously uploaded to imgur.
@@ -339,13 +342,16 @@ impl ConfigBuilder {
 
         let enable_images;
         let imgur_images;
+        let litterbox_images;
 
         if let Some(images) = self.images {
             enable_images = images.enable_images.unwrap_or(false);
             imgur_images = images.imgur_images.unwrap_or(false);
+            litterbox_images = images.litterbox_images.unwrap_or(false);
         } else {
             enable_images = false;
             imgur_images = false;
+            litterbox_images = false;
         }
 
         let url;
@@ -391,6 +397,7 @@ impl ConfigBuilder {
             images: Images {
                 enable_images,
                 imgur_images,
+                litterbox_images,
             },
         }
     }

--- a/jellyfin-rpc-cli/src/main.rs
+++ b/jellyfin-rpc-cli/src/main.rs
@@ -99,8 +99,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .show_paused(conf.discord.show_paused)
         .show_images(conf.images.enable_images)
         .use_imgur(conf.images.imgur_images)
+        .use_litterbox(conf.images.litterbox_images)
         .large_image_text(format!("Jellyfin-RPC v{}", VERSION.unwrap_or("UNKNOWN")))
-        .imgur_urls_file_location(args.image_urls.unwrap_or(get_urls_path()?));
+        .imgur_urls_file_location(args.image_urls.clone().unwrap_or(get_urls_path()?))
+        .litterbox_urls_file_location(args.image_urls.unwrap_or(get_urls_path()?));
 
     if let Some(display) = conf.jellyfin.music.display {
         debug!("Found config.jellyfin.music.display");

--- a/jellyfin-rpc/Cargo.toml
+++ b/jellyfin-rpc/Cargo.toml
@@ -19,5 +19,5 @@ version  = "1.0"
 
 [dependencies.reqwest]
 default-features = false
-features         = ["rustls-tls", "json", "blocking"]
+features         = ["rustls-tls", "json", "blocking", "multipart"]
 version          = "0.12"

--- a/jellyfin-rpc/Cargo.toml
+++ b/jellyfin-rpc/Cargo.toml
@@ -12,6 +12,7 @@ discord-rich-presence = "0.2"
 serde_json            = "1.0"
 log                   = "0.4"
 url                   = "2.5"
+chrono                = "0.4.41"
 
 [dependencies.serde]
 features = ["derive"]

--- a/jellyfin-rpc/src/external/litterbox.rs
+++ b/jellyfin-rpc/src/external/litterbox.rs
@@ -1,0 +1,119 @@
+use std::{
+    fs::{self, File, OpenOptions},
+    io::{Error, ErrorKind, Write},
+    path::Path, time::SystemTime,
+};
+
+use log::{debug};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use reqwest::{blocking::multipart::{ Form, Part }};
+use crate::{ Client, JfResult };
+
+#[derive(Deserialize, Serialize)]
+struct ImageUrl {
+    id: String,
+    url: String,
+}
+
+impl ImageUrl {
+    fn new<T: Into<String>, Y: Into<String>>(id: T, url: Y) -> Self {
+        Self {
+            id: id.into(),
+            url: url.into(),
+        }
+    }
+}
+
+pub fn get_image(client: &Client) -> JfResult<Url> {
+    let mut image_urls = read_file(client)?;
+
+    if let Some(image_url) = image_urls
+        .iter()
+        .find(|image_url| client.session.as_ref().unwrap().item_id == image_url.id)
+    {
+        debug!("Found image url: {}", image_url.url.clone());
+
+        Ok(Url::parse(&image_url.url)?)
+    } else {
+        debug!("No cached litterbox image found. Uploading new image");
+
+        let litterbox_url = upload(client)?;
+
+        debug!("Litterbox response: {}", litterbox_url);
+
+        let image_url = ImageUrl::new(
+            &client.session.as_ref().unwrap().item_id,
+            litterbox_url.as_str(),
+        );
+
+        image_urls.push(image_url);
+
+        let mut file = OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(&client.litterbox_options.urls_location)?;
+
+        file.write_all(serde_json::to_string(&image_urls)?.as_bytes())?;
+
+        let _ = file.flush();
+
+        Ok(litterbox_url)
+    }
+}
+
+fn read_file(client: &Client) -> JfResult<Vec<ImageUrl>> {
+    if let Ok(contents_raw) = fs::read_to_string(&client.litterbox_options.urls_location) {
+        if let Ok(contents) = serde_json::from_str::<Vec<ImageUrl>>(&contents_raw) {
+            return Ok(contents);
+        }
+    }
+
+    let path = Path::new(&client.litterbox_options.urls_location)
+        .parent()
+        .ok_or(Error::new(
+            ErrorKind::Other,
+            "Can't find parent folder of urls.json",
+        ))?;
+
+    fs::create_dir_all(path)?;
+
+    let mut file = File::create(client.litterbox_options.urls_location.clone())?;
+
+    let new: Vec<ImageUrl> = vec![];
+
+    file.write_all(serde_json::to_string(&new)?.as_bytes())?;
+
+    let _ = file.flush();
+
+    Ok(new)
+}
+
+fn upload(client: &Client) -> JfResult<Url> {
+    let image_bytes = client.reqwest.get(client.get_image()?).send()?.bytes()?;
+
+    debug!("Uploading image to litterbox");
+
+    let litterbox_client = reqwest::blocking::Client::builder().build()?;
+    let filename = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+        .to_string();
+
+    let litterbox_form = Form::new()
+        .text("reqtype", "fileupload")
+        .text("time", "24h")
+        .part("fileToUpload", Part::bytes(image_bytes.to_vec()).file_name(filename));
+
+    let res: String = litterbox_client
+        .post("https://litterbox.catbox.moe/resources/internals/api.php")
+        .multipart(litterbox_form)
+        .send()?
+        .text()?;
+
+    debug!("Response from Litterbox: \"{}\"", res.clone());
+
+    Ok(Url::parse(&res)?)
+}

--- a/jellyfin-rpc/src/external/mod.rs
+++ b/jellyfin-rpc/src/external/mod.rs
@@ -1,1 +1,2 @@
 pub mod imgur;
+pub mod litterbox;


### PR DESCRIPTION
Adds support to upload images to https://litterbox.catbox.moe/ with the duration set to 72h, and checks to make sure if the image expires, it uploads a new version.