### PR TITLE
feat(config): prioritize sessions according to the config's username order

### DIFF
--- a/jellyfin-rpc/src/jellyfin.rs
+++ b/jellyfin-rpc/src/jellyfin.rs
@@ -1,7 +1,7 @@
 use serde::{de::Visitor, Deserialize, Serialize};
 use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct RawSession {
     pub user_name: Option<String>,
@@ -307,7 +307,7 @@ impl From<String> for MediaType {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct PlayState {
     pub is_paused: bool,


### PR DESCRIPTION
This is to possibly address #202.

- A user may order their accounts in the jellyfin.username field of the config file to prioritize sessions for users higher up in the list.
- This does not change the behavior when only one user has an active session.

For example, I created two concurrent session with different users, "aryn" and "aryn2".

When my config has `"username": ["aryn", "aryn2"]`, I see the content from `aryn` on discord. When I flip that order, I see the content being played from `aryn2`.

This is my naive attempt, let me know if there is better testing or changes you'd like to see.