### PR TITLE
feat: Allow multiple server URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /.DS_Store
 /.vscode
 /jftest
+.idea
+.gitignore

--- a/jellyfin-rpc-cli/src/config.rs
+++ b/jellyfin-rpc-cli/src/config.rs
@@ -22,7 +22,7 @@ pub struct Config {
 /// This struct contains every "required" part of the config.
 pub struct Jellyfin {
     /// URL to the jellyfin server.
-    pub url: String,
+    pub url: Vec<String>,
     /// Api key from the jellyfin server, used to gather what's being watched.
     pub api_key: String,
     /// Username of the person that info should be gathered from.
@@ -95,7 +95,7 @@ pub struct ConfigBuilder {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct JellyfinBuilder {
-    pub url: String,
+    pub url: Vec<String>,
     pub api_key: String,
     pub username: Username,
     pub music: Option<DisplayOptionsBuilder>,
@@ -217,7 +217,7 @@ impl ConfigBuilder {
     fn new() -> Self {
         Self {
             jellyfin: JellyfinBuilder {
-                url: "".to_string(),
+                url: vec!["".to_owned()],
                 username: Username::String("".to_string()),
                 api_key: "".to_string(),
                 music: None,
@@ -381,12 +381,25 @@ impl ConfigBuilder {
             process_images = true;
         }
 
+        let mut url: Vec<String> = vec!["".to_owned()];
+        /*
         let url;
 
         if self.jellyfin.url.ends_with("/") {
             url = self.jellyfin.url;
         } else {
             url = self.jellyfin.url + "/"
+        }
+        */
+        // Replace to make add "/" to any urls that need it
+        let mut url_num = 0;
+        for u in self.jellyfin.url.iter() {
+            if (u.ends_with("/")) {
+                url[url_num] = u.to_owned();
+            } else {
+                url[url_num] = u.to_owned();
+            }
+            url_num += 1;
         }
 
         Config {

--- a/jellyfin-rpc-cli/src/config.rs
+++ b/jellyfin-rpc-cli/src/config.rs
@@ -381,7 +381,7 @@ impl ConfigBuilder {
             process_images = true;
         }
 
-        let mut url: Vec<String> = vec!["".to_owned()];
+        let mut url: Vec<String> = self.jellyfin.url.to_owned();
         /*
         let url;
 

--- a/jellyfin-rpc/src/tests.rs
+++ b/jellyfin-rpc/src/tests.rs
@@ -15,7 +15,7 @@ fn invalid_url() {
     builder
         .api_key("a1b2c3d4")
         .username("test")
-        .url("url_without_base.com");
+        .url(vec!["url_without_base.com".to_owned()]);
 
     let client = builder.build();
 

--- a/scripts/installer.py
+++ b/scripts/installer.py
@@ -66,18 +66,27 @@ if os.path.isfile(config_path):
 
 if not use_existing:
     print("----------Jellyfin----------")
-    url = input("URL (include http/https): ")
-    api_key = input(f"API key [Create one here: {url}/web/index.html#!/apikeys.html]: ")
+    urls = input("URL (include http/https) (Multiple allowed): ")
+    
+    #Allow inputting multiple URLs
+    url = {}
+    urlNumber = 0
+    for address in urls.split(" "):
+        url[str(urlNumber)] = address
+        urlNumber += 1
+
+    api_key = input(f"API key [Create one here: {url["0"]}/web/index.html#!/apikeys.html]: ")
     print(
         "Enter a single username or enter multiple usernames in a comma separated list."
     )
     username = input("username[s]: ").split(",")
 
     self_signed_cert = None
-    if url.startswith("https://"):
-        self_signed_cert = confirm(
-            message="Are you using a self signed certificate?", default=False, direct=True
-        )
+    for i in url:
+        if url[i].startswith("https://"):
+            self_signed_cert = confirm(
+                message="Are you using a self signed certificate?", default=False, direct=True
+            )
 
     print(
         "If you dont want anything else you can just press enter through all of these"
@@ -236,6 +245,8 @@ if not use_existing:
         "imgur": imgur,
         "images": images,
     }
+
+    print(config)
 
     print(f"\nPlacing config in '{path}'")
 

--- a/scripts/installer.py
+++ b/scripts/installer.py
@@ -66,16 +66,9 @@ if os.path.isfile(config_path):
 
 if not use_existing:
     print("----------Jellyfin----------")
-    urls = input("URL (include http/https) (Multiple allowed): ")
-    
-    #Allow inputting multiple URLs
-    url = {}
-    urlNumber = 0
-    for address in urls.split(" "):
-        url[str(urlNumber)] = address
-        urlNumber += 1
+    url = input("URL (include http/https) (Multiple allowed, separate with spaces): ").split(" ")
 
-    api_key = input(f"API key [Create one here: {url["0"]}/web/index.html#!/apikeys.html]: ")
+    api_key = input(f"API key [Create one here: {url[0]}/web/index.html#!/apikeys.html]: ")
     print(
         "Enter a single username or enter multiple usernames in a comma separated list."
     )
@@ -83,7 +76,7 @@ if not use_existing:
 
     self_signed_cert = None
     for i in url:
-        if url[i].startswith("https://"):
+        if i.startswith("https://"):
             self_signed_cert = confirm(
                 message="Are you using a self signed certificate?", default=False, direct=True
             )


### PR DESCRIPTION
Just a smol thing for a very niche use case I had.
Lets you put in multiple Jellyfin server URLs, and it just tries them and connects to the first available one. 

### Changes:
- Backend: A couple structs, mainly the URL one, Vec<String> instead of String
- `Installer.py`: multiple input for server url (space separated)
- Config created with this should have a URLs field similar to the Usernames field.

*Related: closes #223*