### PR TITLE
Song specific covers

### DIFF
--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -367,7 +367,13 @@ impl Client {
     fn get_image(&self) -> JfResult<Url> {
         let session = self.session.as_ref().unwrap();
 
-        let path = "Items/".to_string() + &session.item_id + "/Images/Primary";
+        let id = if matches!(session.now_playing_item.media_type, MediaType::Music) {
+            &session.now_playing_item.id
+        } else {
+            &session.item_id
+        };
+
+        let path = "Items/".to_string() + id + "/Images/Primary";
 
         let image_url = self.url.join(&path)?;
 

--- a/jellyfin-rpc/src/lib.rs
+++ b/jellyfin-rpc/src/lib.rs
@@ -367,27 +367,29 @@ impl Client {
     fn get_image(&self) -> JfResult<Url> {
         let session = self.session.as_ref().unwrap();
 
-        let id = if matches!(session.now_playing_item.media_type, MediaType::Music) {
-            &session.now_playing_item.id
+        let ids: Vec<&str> = if matches!(session.now_playing_item.media_type, MediaType::Music) {
+            vec![&session.now_playing_item.id, &session.item_id]
         } else {
-            &session.item_id
+            vec![&session.item_id]
         };
 
-        let path = "Items/".to_string() + id + "/Images/Primary";
+        for id in ids {
+            let path = "Items/".to_string() + id + "/Images/Primary";
 
-        let image_url = self.url.join(&path)?;
+            let image_url = self.url.join(&path)?;
 
-        if self
-            .reqwest
-            .get(image_url.as_ref())
-            .send()?
-            .text()?
-            .contains("does not have an image of type Primary")
-        {
-            Err(Box::new(JfError::NoImage))
-        } else {
-            Ok(image_url)
+            if !self
+                .reqwest
+                .get(image_url.as_ref())
+                .send()?
+                .text()?
+                .contains("does not have an image of type Primary")
+            {
+                return Ok(image_url);
+            }
         }
+
+        Err(Box::new(JfError::NoImage))
     }
 
     fn sanitize_display_format(input: &str) -> String {


### PR DESCRIPTION
This makes Jellyfin-RPC prefer track specific art over album art for music when track specific art is present

Before:
<img width="409" height="145" alt="Track playing with album art" src="https://github.com/user-attachments/assets/f9f38e2a-1bac-41db-bbf6-3fb16949f18a" />
After:
<img width="409" height="145" alt="Track playing with track art" src="https://github.com/user-attachments/assets/80b8bfbe-f338-4f2b-9376-f99ddbd19393" />

I'm not sure if this should be toggleable with a config option, since track art requires specific effort from the user to set up for their library