### PR TITLE
Added '-NoProfile' to the powershell command section of installer.py …

### DIFF
--- a/scripts/installer.py
+++ b/scripts/installer.py
@@ -42,7 +42,7 @@ if platform.system() != "Windows":
 else:
     path = os.environ["APPDATA"].removesuffix("\\") + "\\jellyfin-rpc\\"
     subprocess.run(
-        ["powershell", "-Command", f'mkdir "{path}"'],
+        ["powershell", "-NoProfile", "-Command", f'mkdir "{path}"'],
         stdout=subprocess.DEVNULL,
     )
 


### PR DESCRIPTION
…to prevent stalling in non-default user profile configurations that cause the installer to hang. - 2026-01-19 09:16:28 UTC

This is a simple fix that will affect nothing in the install process and make it compatible on any Windows machine.